### PR TITLE
feat: restructure backend and add API routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .DS_Store
 infracost.yml
+.pytest_cache
+venv
+__pycache__

--- a/src/backend/.gitignore
+++ b/src/backend/.gitignore
@@ -1,2 +1,0 @@
-venv
-__pycache__

--- a/src/backend/__init__.py
+++ b/src/backend/__init__.py
@@ -1,0 +1,7 @@
+import os, sys
+
+"""
+relative import fix: https://stackoverflow.com/a/49375740
+"""
+
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -1,26 +1,11 @@
 from fastapi import FastAPI
-from pydantic import BaseModel
-import uvicorn
+from .routes.meetings import router as meeting_router
+from .routes.audio import router as audio_router
+from .routes.bots import router as bot_router
+
 
 app = FastAPI()
 
-
-@app.get("/")
-def read_root():
-    return {"Hello": "World"}
-
-
-class RequestData(BaseModel):
-    name: str
-    age: int
-
-
-@app.get("/test")
-def echo(data: RequestData):
-    name, age = data.model_dump().values()
-    result = f"Hello {name}, you are {age} years old"
-    return {"response": result}
-
-
-if __name__ == "__main__":
-    uvicorn.run(app, host="127.0.0.1", port=8000)
+app.include_router(meeting_router, tags=["meetings"])
+app.include_router(audio_router, tags=["audio"])
+app.include_router(bot_router, tags=["bots"])

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -1,0 +1,1 @@
+# database models

--- a/src/backend/routes/__init__.py
+++ b/src/backend/routes/__init__.py
@@ -1,0 +1,7 @@
+import os, sys
+
+"""
+relative import fix: https://stackoverflow.com/a/49375740
+"""
+
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))

--- a/src/backend/routes/audio.py
+++ b/src/backend/routes/audio.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+class AudioLinkResponse(BaseModel):
+    download_link: str
+
+
+@router.get("/get_audio_download_link/{meeting_id}", response_model=AudioLinkResponse)
+def get_audio_download_link(meeting_id: str):
+    """
+    Endpoint to generate a temporary S3 download link for meeting audio.
+    """
+    download_link = "temporary_s3_link"  # Placeholder
+    return AudioLinkResponse(download_link=download_link)

--- a/src/backend/routes/bots.py
+++ b/src/backend/routes/bots.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+class SetupBotsResponse(BaseModel):
+    status: str
+
+
+@router.post("/setup_bots", response_model=SetupBotsResponse)
+def setup_bots():
+    """
+    Endpoint to setup bots, typically triggered by a lambda CRON job.
+    """
+    return SetupBotsResponse(status="bots setup triggered")
+
+
+class HeartbeatResponse(BaseModel):
+    status: str
+
+
+@router.post("/heartbeat", response_model=HeartbeatResponse)
+def heartbeat():
+    """
+    Endpoint for bots to update the backend with their status.
+    """
+    return HeartbeatResponse(status="heartbeat received")

--- a/src/backend/routes/meetings.py
+++ b/src/backend/routes/meetings.py
@@ -1,0 +1,56 @@
+from typing import List, Optional
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+
+router = APIRouter()
+
+
+class MeetingRequest(BaseModel):
+    link: str
+
+
+class MeetingResponse(BaseModel):
+    meeting_id: str
+
+
+@router.post("/submit_meeting_link", response_model=MeetingResponse)
+def submit_meeting_link(data: MeetingRequest):
+    """
+    Endpoint to submit a meeting link and generate a meeting ID.
+    """
+    meeting_id = "generated_meeting_id"  # Placeholder
+    return MeetingResponse(meeting_id=meeting_id)
+
+
+class MeetingStatusResponse(BaseModel):
+    status: str
+    info: str = None
+
+
+@router.get("/get_meeting/{meeting_id}", response_model=MeetingStatusResponse)
+def get_meeting(meeting_id: str):
+    """
+    Endpoint to get the status and additional info of a meeting by its ID.
+    """
+    status = "meeting_status"  # Placeholder
+    info = "additional_info"  # Placeholder
+    return MeetingStatusResponse(status=status, info=info)
+
+
+class FilterParams(BaseModel):
+    date: Optional[str] = None
+    attendees: Optional[List[str]] = None
+    title: Optional[str] = None
+
+
+@router.get("/get_meetings", response_model=list[MeetingStatusResponse])
+def get_meetings(params: FilterParams = Depends()):
+    """
+    Endpoint to filter and return a list of meetings based on filter parameters.
+    """
+    meetings = [
+        {"status": "status1", "info": "info1"},
+        {"status": "status2", "info": "info2"},
+    ]  # Placeholder
+    return [MeetingStatusResponse(**meeting) for meeting in meetings]


### PR DESCRIPTION
### TL;DR

Restructured backend code, added new routes, and updated .gitignore. Part of MEE-43.

### What changed?

- Implemented new endpoints for submitting meeting links, getting meeting status, filtering meetings, generating audio download links, setting up bots, and handling bot heartbeats
- Created new route files for meetings, audio, and bots
- Refactored main.py to use separate route files
- Added models.py for future database models
- Updated .gitignore to include .pytest_cache, venv, and \_\_pycache__
- Removed src/.gitkeep and src/backend/.gitignore
- Added \_\_init__.py files for relative import fixes

### How to test?

The next PR in the stack adds testing capabilities.

### Why make this change?

This restructuring improves code organization and modularity, making it easier to maintain and expand the backend. The new endpoints will provide essential functionality for managing meetings, handling audio, and controlling bots, which are crucial for the application's core features.