### PR TITLE
feat: add docker file for teams

### DIFF
--- a/src/bots/teams/Dockerfile
+++ b/src/bots/teams/Dockerfile
@@ -1,0 +1,22 @@
+FROM --platform=linux/amd64 node:lts-alpine
+
+# Install pnpm
+RUN npm install -g pnpm
+
+# Set working directory
+WORKDIR /app
+
+# Copy package.json and pnpm-lock.yaml
+COPY package.json pnpm-lock.yaml ./
+
+# Install dependencies
+RUN pnpm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Expose the port the app runs on
+EXPOSE 3000
+
+# Command to run the application
+CMD ["pnpm", "start"]

--- a/src/bots/teams/package.json
+++ b/src/bots/teams/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "src/index.ts",
   "scripts": {
+    "start": "tsx src/index.ts",
     "dev": "tsx src/index.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
     "preinstall": "pnpm dlx puppeteer browsers install chrome"


### PR DESCRIPTION
### TL;DR
Added Docker support for Teams bot and included start script command

### What changed?
- Created a Dockerfile for containerizing the Teams bot using Node.js LTS Alpine image
- Added `start` script command in package.json using tsx to run the application
- Configured Docker container to expose port 3000

### How to test?
1. Build the Docker image:
```bash
docker build -t teams-bot .
```
2. Run the container:
```bash
docker run -p 3000:3000 teams-bot
```
3. Verify the application starts successfully

### Why make this change?
To enable containerized deployment of the Teams bot, making it easier to deploy and run in various environments while ensuring consistency across different platforms.