### PR TITLE
feat: bot joins zoom meeting

### DIFF
--- a/src/bots/zoom/Dockerfile
+++ b/src/bots/zoom/Dockerfile
@@ -1,0 +1,22 @@
+FROM --platform=linux/amd64 node:lts-alpine
+
+# Install pnpm
+RUN npm install -g pnpm
+
+# Set working directory
+WORKDIR /app
+
+# Copy package.json and pnpm-lock.yaml
+COPY package.json pnpm-lock.yaml ./
+
+# Install dependencies
+RUN pnpm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Expose the port the app runs on
+EXPOSE 3000
+
+# Command to run the application
+CMD ["pnpm", "start"]

--- a/src/bots/zoom/package.json
+++ b/src/bots/zoom/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "teams",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/index.ts",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "dev": "tsx src/index.ts",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "preinstall": "pnpm dlx puppeteer browsers install chrome"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "puppeteer": "^23.3.0",
+    "puppeteer-stream": "^3.0.15"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.2"
+  }
+}

--- a/src/bots/zoom/src/index.ts
+++ b/src/bots/zoom/src/index.ts
@@ -1,0 +1,68 @@
+import fs from "fs";
+import puppeteer from "puppeteer";
+import { launch, getStream, wss } from "puppeteer-stream";
+
+const url =
+    "https://us05web.zoom.us/j/84281441381?pwd=N0BHnE1vCY82oom4tnbvVajXRAlrmS.1";
+
+const parseZoomUrl = (input: string): string => {
+  const urlObj = new URL(input);
+  const meetingId = urlObj.pathname.split('/')[2];
+  const params = new URLSearchParams(urlObj.search);
+  const pwd = params.get('pwd');
+  return `https://app.zoom.us/wc/${meetingId}/join?fromPWA=1&pwd=${pwd}`;
+};
+
+console.log(parseZoomUrl(url));
+
+const file = fs.createWriteStream(__dirname + "/test.webm");
+
+(async () => {
+  // Launch the browser and open a new blank page
+  const browser = await launch({
+    executablePath: puppeteer.executablePath(),
+    headless: false,
+    // slowMo: 10,
+    // args: ["--use-fake-ui-for-media-stream"],
+  });
+  const urlObj = new URL(parseZoomUrl(url));
+
+  const context = browser.defaultBrowserContext();
+  context.clearPermissionOverrides();
+  context.overridePermissions(urlObj.origin, ["camera", "microphone"]);
+
+  const page = await browser.newPage();
+
+  await page.goto(urlObj.href);
+
+  const iframe = await page.waitForSelector('.pwa-webclient__iframe');
+  const frame = await iframe?.contentFrame();
+
+  if (frame) {
+    await frame.waitForSelector("#input-for-name");
+    await frame.type("#input-for-name", "Meeting Bot");
+
+    await frame.waitForSelector("button.zm-btn.preview-join-button");
+    await frame.click("button.zm-btn.preview-join-button");
+    
+    await frame.waitForSelector("button.join-audio-by-voip__join-btn", {timeout: 60000});
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    await frame.click("button.join-audio-by-voip__join-btn");
+  }
+
+  const stream = await getStream(page, { audio: true, video: true });
+
+  console.log("Recording...");
+
+  stream.pipe(file);
+  setTimeout(async () => {
+    await stream.destroy();
+    file.close();
+    console.log("finished");
+
+    await browser.close();
+    (await wss).close();
+  }, 1000 * 10);
+
+  // await browser.close();
+})();


### PR DESCRIPTION
### TL;DR
Added initial Zoom bot implementation with Docker configuration for automated meeting joining and recording.

### What changed?
- Created a Dockerfile for containerized deployment using Node.js LTS Alpine
- Implemented a Zoom bot using Puppeteer for automated meeting interactions
- Added functionality to parse and join Zoom meetings via web client
- Included audio/video stream recording capabilities
- Set up package configuration with necessary dependencies

### How to test?
1. Build and run the Docker container
2. Update the Zoom meeting URL in `src/index.ts`
3. Run the bot using `pnpm start`
4. Verify that the bot:
   - Joins the specified Zoom meeting
   - Enters with the name "Meeting Bot"
   - Connects to audio/video
   - Records the meeting stream to `test.webm`

### Why make this change?
To provide an automated solution for joining and recording Zoom meetings programmatically, enabling automated meeting participation and content capture for various use cases.

Completes MEE-64