### PR TITLE
feat: add mp4 recording and meeting end detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ venv
 __pycache__
 node_modules/
 *.webm
+*.mp4

--- a/src/bots/zoom/src/index.ts
+++ b/src/bots/zoom/src/index.ts
@@ -2,9 +2,11 @@ import fs from "fs";
 import puppeteer from "puppeteer";
 import { launch, getStream, wss } from "puppeteer-stream";
 
+// Url from Zoom meeting
 const url =
-    "https://us05web.zoom.us/j/84281441381?pwd=N0BHnE1vCY82oom4tnbvVajXRAlrmS.1";
+    "https://us05web.zoom.us/j/87836813561?pwd=OUqT7h05sUvUyoGPFe1TF6yGtabPeb.1";
 
+// Parse the url to get the web meeting url
 const parseZoomUrl = (input: string): string => {
   const urlObj = new URL(input);
   const meetingId = urlObj.pathname.split('/')[2];
@@ -15,15 +17,15 @@ const parseZoomUrl = (input: string): string => {
 
 console.log(parseZoomUrl(url));
 
-const file = fs.createWriteStream(__dirname + "/test.webm");
+// Create the file to save the recording
+const file = fs.createWriteStream(__dirname + "/test.mp4");
 
+// Launch a browser and open the meeting
 (async () => {
-  // Launch the browser and open a new blank page
   const browser = await launch({
     executablePath: puppeteer.executablePath(),
     headless: false,
     // slowMo: 10,
-    // args: ["--use-fake-ui-for-media-stream"],
   });
   const urlObj = new URL(parseZoomUrl(url));
 
@@ -31,38 +33,67 @@ const file = fs.createWriteStream(__dirname + "/test.webm");
   context.clearPermissionOverrides();
   context.overridePermissions(urlObj.origin, ["camera", "microphone"]);
 
+  // Opens a new page
   const page = await browser.newPage();
 
+  // Navigates to the url
   await page.goto(urlObj.href);
 
+  // Waits for the page's iframe to load
   const iframe = await page.waitForSelector('.pwa-webclient__iframe');
   const frame = await iframe?.contentFrame();
 
   if (frame) {
+    // Waits for the input field and types the name
     await frame.waitForSelector("#input-for-name");
     await frame.type("#input-for-name", "Meeting Bot");
 
+    // Waits for the join button and clicks it
     await frame.waitForSelector("button.zm-btn.preview-join-button");
     await frame.click("button.zm-btn.preview-join-button");
     
+    // Waits for the join with audio button and clicks it
+    // TODO: force join with audio before joining the meeting
     await frame.waitForSelector("button.join-audio-by-voip__join-btn", {timeout: 60000});
     await new Promise(resolve => setTimeout(resolve, 1000));
     await frame.click("button.join-audio-by-voip__join-btn");
   }
 
+  // Start the recording
   const stream = await getStream(page, { audio: true, video: true });
 
   console.log("Recording...");
 
+  // Pipe the stream to the file
   stream.pipe(file);
-  setTimeout(async () => {
-    await stream.destroy();
-    file.close();
-    console.log("finished");
 
-    await browser.close();
-    (await wss).close();
-  }, 1000 * 10);
+  // Constantly check if the meeting has ended every 5 seconds
+  // TODO: see what happens if the bot gets kicked as well
+  const checkMeetingEnd = async () => {
+    // Wait for the "Ok" button to appear which indicates the meeting is over
+    const okButton = await frame?.waitForSelector(
+      'button.zm-btn.zm-btn-legacy.zm-btn--primary.zm-btn__outline--blue',
+      { timeout: 3600000 }
+    );
 
-  // await browser.close();
+    if (okButton) {
+      console.log("Meeting ended");
+      // Click the button to leave the meeting
+      await okButton.click();
+
+      // End the recording and close the file
+      stream.destroy();
+      file.close();
+      console.log("Recording saved");
+
+      // Close the browser
+      await browser.close();
+      (await wss).close();
+    } else {
+      setTimeout(checkMeetingEnd, 1000);
+    }
+  };
+
+  // Start the meeting end check
+  checkMeetingEnd();
 })();


### PR DESCRIPTION
### TL;DR
Added automatic meeting end detection and improved code documentation for the Zoom recording bot.

### What changed?
- Added a function to continuously check for meeting end status
- Implemented automatic recording stop when meeting ends
- Added descriptive comments throughout the code
- Changed recording format from .webm to .mp4
- Updated .gitignore to exclude .mp4 files

### How to test?
1. Start the bot with a valid Zoom meeting URL
2. Let the bot join the meeting and start recording
3. End the meeting from the host side
4. Verify that the bot automatically detects the meeting end
5. Confirm that the recording stops and is saved properly
6. Check that the browser closes automatically

### Why make this change?
Previously, the recording would stop after a fixed timeout of 10 seconds, regardless of the meeting status. This change makes the bot more practical by allowing it to record the entire meeting and automatically stop when the meeting ends, preventing unnecessary resource usage and incomplete recordings.

Completes MEE-68