### PR TITLE
bot-meet-record-video

### DIFF
--- a/src/bots/meets/package.json
+++ b/src/bots/meets/package.json
@@ -12,10 +12,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "dotenv": "^16.4.5",
     "fs-extra": "^11.2.0",
     "playwright": "^1.48.2",
     "playwright-extra": "^4.3.6",
+    "playwright-video": "^2.4.0",
     "puppeteer": "^23.7.0",
     "puppeteer-extra": "^3.3.6",
     "puppeteer-extra-plugin-stealth": "^2.11.2",

--- a/src/bots/meets/pnpm-lock.yaml
+++ b/src/bots/meets/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@ffmpeg-installer/ffmpeg':
+        specifier: ^1.1.0
+        version: 1.1.0
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -20,15 +23,18 @@ importers:
       playwright-extra:
         specifier: ^4.3.6
         version: 4.3.6(playwright-core@1.48.2)(playwright@1.48.2)
+      playwright-video:
+        specifier: ^2.4.0
+        version: 2.4.0
       puppeteer:
-        specifier: ^22.8.2
-        version: 22.15.0(typescript@5.6.2)
+        specifier: ^23.7.0
+        version: 23.8.0(typescript@5.6.2)
       puppeteer-extra:
         specifier: ^3.3.6
-        version: 3.3.6(puppeteer-core@23.3.0)(puppeteer@22.15.0(typescript@5.6.2))
+        version: 3.3.6(puppeteer-core@23.8.0)(puppeteer@23.8.0(typescript@5.6.2))
       puppeteer-extra-plugin-stealth:
         specifier: ^2.11.2
-        version: 2.11.2(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.3.0)(puppeteer@22.15.0(typescript@5.6.2)))
+        version: 2.11.2(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.8.0)(puppeteer@23.8.0(typescript@5.6.2)))
       puppeteer-stream:
         specifier: 3.0.9
         version: 3.0.9(typescript@5.6.2)
@@ -194,6 +200,49 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@ffmpeg-installer/darwin-arm64@4.1.5':
+    resolution: {integrity: sha512-hYqTiP63mXz7wSQfuqfFwfLOfwwFChUedeCVKkBtl/cliaTM7/ePI9bVzfZ2c+dWu3TqCwLDRWNSJ5pqZl8otA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ffmpeg-installer/darwin-x64@4.1.0':
+    resolution: {integrity: sha512-Z4EyG3cIFjdhlY8wI9aLUXuH8nVt7E9SlMVZtWvSPnm2sm37/yC2CwjUzyCQbJbySnef1tQwGG2Sx+uWhd9IAw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ffmpeg-installer/ffmpeg@1.1.0':
+    resolution: {integrity: sha512-Uq4rmwkdGxIa9A6Bd/VqqYbT7zqh1GrT5/rFwCwKM70b42W5gIjWeVETq6SdcL0zXqDtY081Ws/iJWhr1+xvQg==}
+
+  '@ffmpeg-installer/linux-arm64@4.1.4':
+    resolution: {integrity: sha512-dljEqAOD0oIM6O6DxBW9US/FkvqvQwgJ2lGHOwHDDwu/pX8+V0YsDL1xqHbj1DMX/+nP9rxw7G7gcUvGspSoKg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@ffmpeg-installer/linux-arm@4.1.3':
+    resolution: {integrity: sha512-NDf5V6l8AfzZ8WzUGZ5mV8O/xMzRag2ETR6+TlGIsMHp81agx51cqpPItXPib/nAZYmo55Bl2L6/WOMI3A5YRg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@ffmpeg-installer/linux-ia32@4.1.0':
+    resolution: {integrity: sha512-0LWyFQnPf+Ij9GQGD034hS6A90URNu9HCtQ5cTqo5MxOEc7Rd8gLXrJvn++UmxhU0J5RyRE9KRYstdCVUjkNOQ==}
+    cpu: [ia32]
+    os: [linux]
+
+  '@ffmpeg-installer/linux-x64@4.1.0':
+    resolution: {integrity: sha512-Y5BWhGLU/WpQjOArNIgXD3z5mxxdV8c41C+U15nsE5yF8tVcdCGet5zPs5Zy3Ta6bU7haGpIzryutqCGQA/W8A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@ffmpeg-installer/win32-ia32@4.1.0':
+    resolution: {integrity: sha512-FV2D7RlaZv/lrtdhaQ4oETwoFUsUjlUiasiZLDxhEUPdNDWcH1OU9K1xTvqz+OXLdsmYelUDuBS/zkMOTtlUAw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@ffmpeg-installer/win32-x64@4.1.0':
+    resolution: {integrity: sha512-Drt5u2vzDnIONf4ZEkKtFlbvwj6rI3kxw1Ck9fpudmtgaZIHD4ucsWB2lCZBXRxJgXR+2IMSti+4rtM4C4rXgg==}
+    cpu: [x64]
+    os: [win32]
+
   '@puppeteer/browsers@1.4.6':
     resolution: {integrity: sha512-x4BEjr2SjOPowNeiguzjozQbsc6h437ovD/wu+JpaenxVLm3jkgzHY2xOslMTp50HoTvQreMjiexiGQw1sqZlQ==}
     engines: {node: '>=16.3.0'}
@@ -204,13 +253,8 @@ packages:
       typescript:
         optional: true
 
-  '@puppeteer/browsers@2.3.0':
-    resolution: {integrity: sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  '@puppeteer/browsers@2.4.0':
-    resolution: {integrity: sha512-x8J1csfIygOwf6D6qUAZ0ASk3z63zPb7wkNeHRerCMh82qWKUrOgkuP005AJC8lDL6/evtXETGEJVcwykKT4/g==}
+  '@puppeteer/browsers@2.4.1':
+    resolution: {integrity: sha512-0kdAbmic3J09I6dT8e9vE2JOCSt13wHCW5x/ly8TSt2bDtuIWe2TgLZZDHdcziw9AVCzflMAXCrVyRIhIs44Ng==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -251,6 +295,13 @@ packages:
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
+
+  async@0.2.10:
+    resolution: {integrity: sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==}
+
+  at-least-node@1.0.0:
+    resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
+    engines: {node: '>= 4.0.0'}
 
   b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
@@ -298,13 +349,8 @@ packages:
     peerDependencies:
       devtools-protocol: '*'
 
-  chromium-bidi@0.6.3:
-    resolution: {integrity: sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==}
-    peerDependencies:
-      devtools-protocol: '*'
-
-  chromium-bidi@0.6.5:
-    resolution: {integrity: sha512-RuLrmzYrxSb0s9SgpB+QN5jJucPduZQ/9SIe76MDxYJuecPW5mxMdacJ1f4EtgiV+R0p3sCkznTMvH0MPGFqjA==}
+  chromium-bidi@0.8.0:
+    resolution: {integrity: sha512-uJydbGdTw0DEUjhoogGveneJVWX/9YuqkWePzMmkBYwtdAqo5d3J/ovNKFr+/2hWXYmYCr6it8mSSTIj6SS6Ug==}
     peerDependencies:
       devtools-protocol: '*'
 
@@ -371,11 +417,8 @@ packages:
   devtools-protocol@0.0.1147663:
     resolution: {integrity: sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ==}
 
-  devtools-protocol@0.0.1312386:
-    resolution: {integrity: sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==}
-
-  devtools-protocol@0.0.1330662:
-    resolution: {integrity: sha512-pzh6YQ8zZfz3iKlCvgzVCu22NdpZ8hNmwU6WnQjNVquh0A9iVosPtNLWDwaWVGyrntQlltPFztTMK5Cg6lfCuw==}
+  devtools-protocol@0.0.1367902:
+    resolution: {integrity: sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==}
 
   dotenv@16.4.5:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
@@ -432,6 +475,10 @@ packages:
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
+  fluent-ffmpeg@2.1.3:
+    resolution: {integrity: sha512-Be3narBNt2s6bsaqP6Jzq91heDgOEaDCJAXcE3qcma/EJBSy5FB4cvO31XBInuAuKBx8Kptf8dkhjK0IOru39Q==}
+    engines: {node: '>=18'}
+
   for-in@0.1.8:
     resolution: {integrity: sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==}
     engines: {node: '>=0.10.0'}
@@ -451,6 +498,10 @@ packages:
   fs-extra@11.2.0:
     resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
     engines: {node: '>=14.14'}
+
+  fs-extra@9.1.0:
+    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
+    engines: {node: '>=10'}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -530,6 +581,9 @@ packages:
   is-plain-object@2.0.4:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
     engines: {node: '>=0.10.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
@@ -659,6 +713,10 @@ packages:
       playwright-core:
         optional: true
 
+  playwright-video@2.4.0:
+    resolution: {integrity: sha512-NA4ND29uaMEy78wXepH0dS2UnFd/GxSoScyoViql8mv5jpkEPHJPqxBKTO8l3rYbbDfFqrP/vQUPmsCB1UNXng==}
+    engines: {node: '>=10.15.0'}
+
   playwright@1.48.2:
     resolution: {integrity: sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==}
     engines: {node: '>=18'}
@@ -691,12 +749,8 @@ packages:
       typescript:
         optional: true
 
-  puppeteer-core@22.15.0:
-    resolution: {integrity: sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==}
-    engines: {node: '>=18'}
-
-  puppeteer-core@23.3.0:
-    resolution: {integrity: sha512-sB2SsVMFs4gKad5OCdv6w5vocvtEUrRl0zQqSyRPbo/cj1Ktbarmhxy02Zyb9R9HrssBcJDZbkrvBnbaesPyYg==}
+  puppeteer-core@23.8.0:
+    resolution: {integrity: sha512-c2ymGN2M//We7pC+JhP2dE/g4+qnT89BO+EMSZyJmecN3DN6RNqErA7eH7DrWoNIcU75r2nP4VHa4pswAL6NVg==}
     engines: {node: '>=18'}
 
   puppeteer-extra-plugin-stealth@2.11.2:
@@ -765,8 +819,8 @@ packages:
   puppeteer-stream@3.0.9:
     resolution: {integrity: sha512-Y/L6wYRfXEvggAqQKRBYmn1c3rRXwRAj7kyGpqbQ9WWfLfLMWlC5TWBA3Nc4GdTGQe2JL6MeiyAQh/ELNu2ddg==}
 
-  puppeteer@22.15.0:
-    resolution: {integrity: sha512-XjCY1SiSEi1T7iSYuxS82ft85kwDJUS7wj1Z0eGVXKdtr5g4xnVcbjwxhq5xBnpK/E7x1VZZoJDxpjAOasHT4Q==}
+  puppeteer@23.8.0:
+    resolution: {integrity: sha512-MFWDMWoCcOpwNwQIjA9gPKWrEUbj8bLCzkK56w5lZPMUT6wK4FfpgOEPxKffVmXEMYMZzgcjxzqy15b/Q1ibaw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -880,6 +934,10 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -1016,6 +1074,41 @@ snapshots:
   '@esbuild/win32-x64@0.23.1':
     optional: true
 
+  '@ffmpeg-installer/darwin-arm64@4.1.5':
+    optional: true
+
+  '@ffmpeg-installer/darwin-x64@4.1.0':
+    optional: true
+
+  '@ffmpeg-installer/ffmpeg@1.1.0':
+    optionalDependencies:
+      '@ffmpeg-installer/darwin-arm64': 4.1.5
+      '@ffmpeg-installer/darwin-x64': 4.1.0
+      '@ffmpeg-installer/linux-arm': 4.1.3
+      '@ffmpeg-installer/linux-arm64': 4.1.4
+      '@ffmpeg-installer/linux-ia32': 4.1.0
+      '@ffmpeg-installer/linux-x64': 4.1.0
+      '@ffmpeg-installer/win32-ia32': 4.1.0
+      '@ffmpeg-installer/win32-x64': 4.1.0
+
+  '@ffmpeg-installer/linux-arm64@4.1.4':
+    optional: true
+
+  '@ffmpeg-installer/linux-arm@4.1.3':
+    optional: true
+
+  '@ffmpeg-installer/linux-ia32@4.1.0':
+    optional: true
+
+  '@ffmpeg-installer/linux-x64@4.1.0':
+    optional: true
+
+  '@ffmpeg-installer/win32-ia32@4.1.0':
+    optional: true
+
+  '@ffmpeg-installer/win32-x64@4.1.0':
+    optional: true
+
   '@puppeteer/browsers@1.4.6(typescript@5.6.2)':
     dependencies:
       debug: 4.3.4
@@ -1030,7 +1123,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@puppeteer/browsers@2.3.0':
+  '@puppeteer/browsers@2.4.1':
     dependencies:
       debug: 4.3.7
       extract-zip: 2.0.1
@@ -1042,20 +1135,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - supports-color
-
-  '@puppeteer/browsers@2.4.0':
-    dependencies:
-      debug: 4.3.7
-      extract-zip: 2.0.1
-      progress: 2.0.3
-      proxy-agent: 6.4.0
-      semver: 7.6.3
-      tar-fs: 3.0.6
-      unbzip2-stream: 1.4.3
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
@@ -1094,6 +1173,10 @@ snapshots:
   ast-types@0.13.4:
     dependencies:
       tslib: 2.8.1
+
+  async@0.2.10: {}
+
+  at-least-node@1.0.0: {}
 
   b4a@1.6.7: {}
 
@@ -1145,20 +1228,12 @@ snapshots:
       devtools-protocol: 0.0.1147663
       mitt: 3.0.0
 
-  chromium-bidi@0.6.3(devtools-protocol@0.0.1312386):
+  chromium-bidi@0.8.0(devtools-protocol@0.0.1367902):
     dependencies:
-      devtools-protocol: 0.0.1312386
+      devtools-protocol: 0.0.1367902
       mitt: 3.0.1
       urlpattern-polyfill: 10.0.0
       zod: 3.23.8
-
-  chromium-bidi@0.6.5(devtools-protocol@0.0.1330662):
-    dependencies:
-      devtools-protocol: 0.0.1330662
-      mitt: 3.0.1
-      urlpattern-polyfill: 10.0.0
-      zod: 3.23.8
-    optional: true
 
   cliui@8.0.1:
     dependencies:
@@ -1217,10 +1292,7 @@ snapshots:
 
   devtools-protocol@0.0.1147663: {}
 
-  devtools-protocol@0.0.1312386: {}
-
-  devtools-protocol@0.0.1330662:
-    optional: true
+  devtools-protocol@0.0.1367902: {}
 
   dotenv@16.4.5: {}
 
@@ -1295,6 +1367,11 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
+  fluent-ffmpeg@2.1.3:
+    dependencies:
+      async: 0.2.10
+      which: 1.3.1
+
   for-in@0.1.8: {}
 
   for-in@1.0.2: {}
@@ -1311,6 +1388,13 @@ snapshots:
 
   fs-extra@11.2.0:
     dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
+
+  fs-extra@9.1.0:
+    dependencies:
+      at-least-node: 1.0.0
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.1
@@ -1397,6 +1481,8 @@ snapshots:
   is-plain-object@2.0.4:
     dependencies:
       isobject: 3.0.1
+
+  isexe@2.0.0: {}
 
   isobject@3.0.1: {}
 
@@ -1513,6 +1599,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  playwright-video@2.4.0:
+    dependencies:
+      debug: 4.3.7
+      fluent-ffmpeg: 2.1.3
+      fs-extra: 9.1.0
+      playwright-core: 1.48.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   playwright@1.48.2:
     dependencies:
       playwright-core: 1.48.2
@@ -1570,86 +1666,73 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  puppeteer-core@22.15.0:
+  puppeteer-core@23.8.0:
     dependencies:
-      '@puppeteer/browsers': 2.3.0
-      chromium-bidi: 0.6.3(devtools-protocol@0.0.1312386)
+      '@puppeteer/browsers': 2.4.1
+      chromium-bidi: 0.8.0(devtools-protocol@0.0.1367902)
       debug: 4.3.7
-      devtools-protocol: 0.0.1312386
-      ws: 8.18.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  puppeteer-core@23.3.0:
-    dependencies:
-      '@puppeteer/browsers': 2.4.0
-      chromium-bidi: 0.6.5(devtools-protocol@0.0.1330662)
-      debug: 4.3.7
-      devtools-protocol: 0.0.1330662
+      devtools-protocol: 0.0.1367902
       typed-query-selector: 2.12.0
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
-    optional: true
 
-  puppeteer-extra-plugin-stealth@2.11.2(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.3.0)(puppeteer@22.15.0(typescript@5.6.2))):
+  puppeteer-extra-plugin-stealth@2.11.2(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.8.0)(puppeteer@23.8.0(typescript@5.6.2))):
     dependencies:
       debug: 4.3.7
-      puppeteer-extra-plugin: 3.2.3(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.3.0)(puppeteer@22.15.0(typescript@5.6.2)))
-      puppeteer-extra-plugin-user-preferences: 2.4.1(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.3.0)(puppeteer@22.15.0(typescript@5.6.2)))
+      puppeteer-extra-plugin: 3.2.3(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.8.0)(puppeteer@23.8.0(typescript@5.6.2)))
+      puppeteer-extra-plugin-user-preferences: 2.4.1(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.8.0)(puppeteer@23.8.0(typescript@5.6.2)))
     optionalDependencies:
       playwright-extra: 4.3.6(playwright-core@1.48.2)(playwright@1.48.2)
-      puppeteer-extra: 3.3.6(puppeteer-core@23.3.0)(puppeteer@22.15.0(typescript@5.6.2))
+      puppeteer-extra: 3.3.6(puppeteer-core@23.8.0)(puppeteer@23.8.0(typescript@5.6.2))
     transitivePeerDependencies:
       - supports-color
 
-  puppeteer-extra-plugin-user-data-dir@2.4.1(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.3.0)(puppeteer@22.15.0(typescript@5.6.2))):
+  puppeteer-extra-plugin-user-data-dir@2.4.1(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.8.0)(puppeteer@23.8.0(typescript@5.6.2))):
     dependencies:
       debug: 4.3.7
       fs-extra: 10.1.0
-      puppeteer-extra-plugin: 3.2.3(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.3.0)(puppeteer@22.15.0(typescript@5.6.2)))
+      puppeteer-extra-plugin: 3.2.3(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.8.0)(puppeteer@23.8.0(typescript@5.6.2)))
       rimraf: 3.0.2
     optionalDependencies:
       playwright-extra: 4.3.6(playwright-core@1.48.2)(playwright@1.48.2)
-      puppeteer-extra: 3.3.6(puppeteer-core@23.3.0)(puppeteer@22.15.0(typescript@5.6.2))
+      puppeteer-extra: 3.3.6(puppeteer-core@23.8.0)(puppeteer@23.8.0(typescript@5.6.2))
     transitivePeerDependencies:
       - supports-color
 
-  puppeteer-extra-plugin-user-preferences@2.4.1(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.3.0)(puppeteer@22.15.0(typescript@5.6.2))):
+  puppeteer-extra-plugin-user-preferences@2.4.1(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.8.0)(puppeteer@23.8.0(typescript@5.6.2))):
     dependencies:
       debug: 4.3.7
       deepmerge: 4.3.1
-      puppeteer-extra-plugin: 3.2.3(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.3.0)(puppeteer@22.15.0(typescript@5.6.2)))
-      puppeteer-extra-plugin-user-data-dir: 2.4.1(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.3.0)(puppeteer@22.15.0(typescript@5.6.2)))
+      puppeteer-extra-plugin: 3.2.3(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.8.0)(puppeteer@23.8.0(typescript@5.6.2)))
+      puppeteer-extra-plugin-user-data-dir: 2.4.1(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.8.0)(puppeteer@23.8.0(typescript@5.6.2)))
     optionalDependencies:
       playwright-extra: 4.3.6(playwright-core@1.48.2)(playwright@1.48.2)
-      puppeteer-extra: 3.3.6(puppeteer-core@23.3.0)(puppeteer@22.15.0(typescript@5.6.2))
+      puppeteer-extra: 3.3.6(puppeteer-core@23.8.0)(puppeteer@23.8.0(typescript@5.6.2))
     transitivePeerDependencies:
       - supports-color
 
-  puppeteer-extra-plugin@3.2.3(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.3.0)(puppeteer@22.15.0(typescript@5.6.2))):
+  puppeteer-extra-plugin@3.2.3(playwright-extra@4.3.6(playwright-core@1.48.2)(playwright@1.48.2))(puppeteer-extra@3.3.6(puppeteer-core@23.8.0)(puppeteer@23.8.0(typescript@5.6.2))):
     dependencies:
       '@types/debug': 4.1.12
       debug: 4.3.7
       merge-deep: 3.0.3
     optionalDependencies:
       playwright-extra: 4.3.6(playwright-core@1.48.2)(playwright@1.48.2)
-      puppeteer-extra: 3.3.6(puppeteer-core@23.3.0)(puppeteer@22.15.0(typescript@5.6.2))
+      puppeteer-extra: 3.3.6(puppeteer-core@23.8.0)(puppeteer@23.8.0(typescript@5.6.2))
     transitivePeerDependencies:
       - supports-color
 
-  puppeteer-extra@3.3.6(puppeteer-core@23.3.0)(puppeteer@22.15.0(typescript@5.6.2)):
+  puppeteer-extra@3.3.6(puppeteer-core@23.8.0)(puppeteer@23.8.0(typescript@5.6.2)):
     dependencies:
       '@types/debug': 4.1.12
       debug: 4.3.7
       deepmerge: 4.3.1
     optionalDependencies:
-      puppeteer: 22.15.0(typescript@5.6.2)
-      puppeteer-core: 23.3.0
+      puppeteer: 23.8.0(typescript@5.6.2)
+      puppeteer-core: 23.8.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1664,12 +1747,14 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  puppeteer@22.15.0(typescript@5.6.2):
+  puppeteer@23.8.0(typescript@5.6.2):
     dependencies:
-      '@puppeteer/browsers': 2.3.0
+      '@puppeteer/browsers': 2.4.1
+      chromium-bidi: 0.8.0(devtools-protocol@0.0.1367902)
       cosmiconfig: 9.0.0(typescript@5.6.2)
-      devtools-protocol: 0.0.1312386
-      puppeteer-core: 22.15.0
+      devtools-protocol: 0.0.1367902
+      puppeteer-core: 23.8.0
+      typed-query-selector: 2.12.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -1770,8 +1855,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  typed-query-selector@2.12.0:
-    optional: true
+  typed-query-selector@2.12.0: {}
 
   typescript@5.6.2: {}
 
@@ -1793,6 +1877,10 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  which@1.3.1:
+    dependencies:
+      isexe: 2.0.0
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/src/bots/meets/src/index.ts
+++ b/src/bots/meets/src/index.ts
@@ -1,13 +1,15 @@
 import { chromium } from 'playwright-extra';
 import StealthPlugin from 'puppeteer-extra-plugin-stealth';
+import { saveVideo } from 'playwright-video';
 import fs from 'fs-extra';
+import { CaptureOptions } from 'playwright-video/build/PageVideoCapture';
 
 const stealthPlugin = StealthPlugin();
 stealthPlugin.enabledEvasions.delete('iframe.contentWindow');
 stealthPlugin.enabledEvasions.delete('media.codecs');
 chromium.use(stealthPlugin);
 
-const url = "https://meet.google.com/wvx-raiz-zee";
+const url = "https://meet.google.com/tqx-axzw-ore";
 
 // const file = fs.createWriteStream(__dirname + "/test.webm");
 
@@ -28,7 +30,7 @@ const url = "https://meet.google.com/wvx-raiz-zee";
     args: browserArgs
   });
 
-  
+
   // Create Browser Context
   const context = await browser.newContext({
     permissions: ['camera', 'microphone'],
@@ -47,9 +49,9 @@ const url = "https://meet.google.com/wvx-raiz-zee";
 
   console.log('Waiting for the input field to be visible...');
   await page.waitForSelector('input[type="text"][aria-label="Your name"]');
-  
-  console.log('Waiting for 10 seconds...');
-  await page.waitForTimeout(10000);
+
+  console.log('Waiting for 1 seconds...');
+  await page.waitForTimeout(1000);
 
   console.log('Filling the input field with the name...');
   await page.fill('input[type="text"][aria-label="Your name"]', fullName);
@@ -60,7 +62,6 @@ const url = "https://meet.google.com/wvx-raiz-zee";
   console.log('Clicking the "Ask to join" button...');
   await page.click('//button[.//span[text()="Ask to join"]]');
 
-
   //
   const leaveButton = `//button[@aria-label="Leave call"]`
   const peopleButton = `//button[@aria-label="People"]`
@@ -69,23 +70,30 @@ const url = "https://meet.google.com/wvx-raiz-zee";
   //Should Exit after 1 Minute
   console.log('Awaiting Entry ....')
   await page.waitForSelector(leaveButton, { timeout: 60000 })
-  
 
   console.log('Joined Call.')
+  console.log('Starting Recording ....')
+
+
   console.log('Finding People Button..')
   await page.waitForSelector(peopleButton)
   await page.click(peopleButton);
   console.log('Clicked People Button.')
-  
-  
-  //Start Recording
 
+
+  //Start Recording
+  const recordingOptions: CaptureOptions = {
+    followPopups: false,
+    fps: 25,
+  }
+  const recorder = await saveVideo(page, './test.mp4', recordingOptions);
 
   // Detect All but Me Person Leave
   await page.locator('//span[.//div[text()="Contributors"]]//div[text()="1"]').waitFor()
-  console.log('Detected 1 Person in the call -- exiting ...');  
+  console.log('Detected 1 Person in the call -- exiting ...');
 
   // End Recording
+  await recorder.stop();
 
   // Leave Meeting
   // Close Browser
@@ -94,6 +102,5 @@ const url = "https://meet.google.com/wvx-raiz-zee";
 
   await browser.close();
   console.log('Closed Browser.')
-
 
 })();


### PR DESCRIPTION
### TL;DR
Added video recording capabilities to Google Meet bot using playwright-video

Completes MEE-66

### What changed?
- Added `@ffmpeg-installer/ffmpeg` and `playwright-video` dependencies
- Integrated video recording functionality into the Meet bot
- Configured recording options with 25 fps
- Added automatic recording stop when leaving the meeting
- Updated the test Meet URL

### How to test?
1. Run the bot with the updated dependencies
2. Join a Google Meet call
3. Verify that a video file (test.mp4) is created
4. Confirm recording stops automatically when the last person leaves
5. Check the recorded video quality and fps settings

### Why make this change?
To capture and preserve Google Meet sessions for documentation, analysis, or record-keeping purposes. The video recording feature allows for automated capture of meeting content without manual intervention.