### PR TITLE
fix: teams bot for mac

### DIFF
--- a/src/bots/teams/src/index.ts
+++ b/src/bots/teams/src/index.ts
@@ -41,6 +41,9 @@ const s3Client = new S3Client({
 const recordingPath = __dirname + "/recording.webm";
 const file = fs.createWriteStream(recordingPath);
 
+const leaveButtonSelector =
+  'button[aria-label="Leave (Ctrl+Shift+H)"], button[aria-label="Leave (⌘+Shift+H)"]';
+
 (async () => {
   // Launch the browser and open a new blank page
   const browser = await launch({
@@ -82,7 +85,7 @@ const file = fs.createWriteStream(recordingPath);
   });
 
   // First wait for the leave button to appear (meaning we've joined the meeting)
-  await page.waitForSelector('button[aria-label="Leave (Ctrl+Shift+H)"]', {
+  await page.waitForSelector(leaveButtonSelector, {
     timeout: 30000,
   });
   console.log("Successfully joined meeting");
@@ -96,13 +99,9 @@ const file = fs.createWriteStream(recordingPath);
 
   // Then wait for meeting to end by watching for the "Leave" button to disappear
   await page.waitForFunction(
-    () => {
-      const leaveButton = document.querySelector(
-        'button[aria-label="Leave (Ctrl+Shift+H)"]'
-      );
-      return !leaveButton;
-    },
-    { timeout: 0 }
+    (selector) => !document.querySelector(selector),
+    {},
+    leaveButtonSelector
   );
   console.log("Meeting ended");
 


### PR DESCRIPTION
### TL;DR
Added support for both Windows and Mac in Teams meeting leave button detection.

### What changed?
Updated the leave button selector to handle both Windows (`Ctrl+Shift+H`) and Mac (`⌘+Shift+H`) keyboard shortcuts. Extracted the selector into a constant to maintain consistency across multiple uses and simplified the page wait function.

The selector was also being a  bit finicky so I changed the logic slightly to follow this example from documentation:

```
@example
Arguments can be passed from Node.js to pageFunction:

const selector = '.foo';
await page.waitForFunction(
  selector => !!document.querySelector(selector),
  {},
  selector
);
```

### How to test?
1. Join a Teams meeting using the bot
2. Verify the bot successfully detects when it has joined the meeting
3. Test on both Windows and Mac environments to ensure the leave button is properly detected
4. End the meeting and confirm the bot recognizes the meeting has ended

### Why make this change?
The previous implementation only supported Windows keyboard shortcuts, causing the bot to fail on Mac environments. This change ensures cross-platform compatibility for Teams meeting automation.