### PR TITLE
refactor: use puppeteer base image and clean up docker config

### DIFF
--- a/src/bots/zoom/Dockerfile
+++ b/src/bots/zoom/Dockerfile
@@ -1,34 +1,30 @@
-FROM --platform=linux/amd64 node:22-alpine
+FROM --platform=linux/amd64 ghcr.io/puppeteer/puppeteer:latest
+
+ENV \
+    # Configure default locale (important for chrome-headless-shell).
+    LANG=en_US.UTF-8 \
+    # UID of the non-root user 'pptruser'
+    PPTRUSER_UID=10042
 
 # Install pnpm
+USER root
 RUN npm install -g pnpm
-
-# Install Chrome dependencies
-RUN apk add --no-cache \
-    chromium \
-    nss \
-    freetype \
-    freetype-dev \
-    harfbuzz \
-    ca-certificates \
-    ttf-freefont \
-    nodejs \
-    yarn
-# Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
-    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+USER $PPTRUSER_UID
 
 # Set working directory
-WORKDIR /app
+WORKDIR /home/pptruser
 
-# Copy package.json, pnpm-lock.yaml, and .env file
+# Copy package.json, pnpm-lock.yaml, .env file, and src/index.ts into the src directory
 COPY package.json pnpm-lock.yaml .env ./
+COPY src/index.ts ./src/
 
-# Install dependencies
+# Install dependencies inside the container
 RUN pnpm install --frozen-lockfile
 
-# Copy the rest of the application code
-COPY . .
+# Change ownership of the files
+USER root
+RUN chown -R pptruser:pptruser .
+USER $PPTRUSER_UID
 
 # Expose the port the app runs on
 EXPOSE 3000

--- a/src/bots/zoom/package.json
+++ b/src/bots/zoom/package.json
@@ -15,8 +15,8 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.696.0",
     "dotenv": "^16.4.5",
-    "puppeteer": "^23.3.0",
-    "puppeteer-stream": "^3.0.15"
+    "puppeteer": "^23.9.0",
+    "puppeteer-stream": "^3.0.19"
   },
   "devDependencies": {
     "tsx": "^4.19.0",

--- a/src/bots/zoom/pnpm-lock.yaml
+++ b/src/bots/zoom/pnpm-lock.yaml
@@ -15,10 +15,10 @@ importers:
         specifier: ^16.4.5
         version: 16.4.5
       puppeteer:
-        specifier: ^23.3.0
-        version: 23.7.1(typescript@5.6.3)
+        specifier: ^23.9.0
+        version: 23.9.0(typescript@5.6.3)
       puppeteer-stream:
-        specifier: ^3.0.15
+        specifier: ^3.0.19
         version: 3.0.19
     devDependencies:
       tsx:
@@ -674,8 +674,8 @@ packages:
   devtools-protocol@0.0.1312386:
     resolution: {integrity: sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==}
 
-  devtools-protocol@0.0.1354347:
-    resolution: {integrity: sha512-BlmkSqV0V84E2WnEnoPnwyix57rQxAM5SKJjf4TbYOCGLAWtz8CDH8RIaGOjPgPCXo2Mce3kxSY497OySidY3Q==}
+  devtools-protocol@0.0.1367902:
+    resolution: {integrity: sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==}
 
   dotenv@16.4.5:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
@@ -865,15 +865,15 @@ packages:
     resolution: {integrity: sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==}
     engines: {node: '>=18'}
 
-  puppeteer-core@23.7.1:
-    resolution: {integrity: sha512-Om/qCZhd+HLoAr7GltrRAZpS3uOXwHu7tXAoDbNcJADHjG2zeAlDArgyIPXYGG4QB/EQUHk13Q6RklNxGM73Pg==}
+  puppeteer-core@23.9.0:
+    resolution: {integrity: sha512-hLVrav2HYMVdK0YILtfJwtnkBAwNOztUdR4aJ5YKDvgsbtagNr6urUJk9HyjRA9e+PaLI3jzJ0wM7A4jSZ7Qxw==}
     engines: {node: '>=18'}
 
   puppeteer-stream@3.0.19:
     resolution: {integrity: sha512-8s4MLZFtF66XCKYVqadnu1aaqZgbbtvQZVfGtlt5CD869wbvo5SXd34IHGP1gngKRim5KHAYjID+ANy3vb2ywQ==}
 
-  puppeteer@23.7.1:
-    resolution: {integrity: sha512-jS6XehagMvxQ12etwY/4EOYZ0Sm8GAsrtGhdQn4AqpJAyHc3RYl7tGd4QYh/MmShDw8sF9FWYQqGidhoXaqokQ==}
+  puppeteer@23.9.0:
+    resolution: {integrity: sha512-WfB8jGwFV+qrD9dcJJVvWPFJBU6kxeu2wxJz9WooDGfM3vIiKLgzImEDBxUQnCBK/2cXB3d4dV6gs/LLpgfLDg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2034,9 +2034,9 @@ snapshots:
       urlpattern-polyfill: 10.0.0
       zod: 3.23.8
 
-  chromium-bidi@0.8.0(devtools-protocol@0.0.1354347):
+  chromium-bidi@0.8.0(devtools-protocol@0.0.1367902):
     dependencies:
-      devtools-protocol: 0.0.1354347
+      devtools-protocol: 0.0.1367902
       mitt: 3.0.1
       urlpattern-polyfill: 10.0.0
       zod: 3.23.8
@@ -2076,7 +2076,7 @@ snapshots:
 
   devtools-protocol@0.0.1312386: {}
 
-  devtools-protocol@0.0.1354347: {}
+  devtools-protocol@0.0.1367902: {}
 
   dotenv@16.4.5: {}
 
@@ -2312,12 +2312,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  puppeteer-core@23.7.1:
+  puppeteer-core@23.9.0:
     dependencies:
       '@puppeteer/browsers': 2.4.1
-      chromium-bidi: 0.8.0(devtools-protocol@0.0.1354347)
+      chromium-bidi: 0.8.0(devtools-protocol@0.0.1367902)
       debug: 4.3.7
-      devtools-protocol: 0.0.1354347
+      devtools-protocol: 0.0.1367902
       typed-query-selector: 2.12.0
       ws: 8.18.0
     transitivePeerDependencies:
@@ -2334,13 +2334,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  puppeteer@23.7.1(typescript@5.6.3):
+  puppeteer@23.9.0(typescript@5.6.3):
     dependencies:
       '@puppeteer/browsers': 2.4.1
-      chromium-bidi: 0.8.0(devtools-protocol@0.0.1354347)
+      chromium-bidi: 0.8.0(devtools-protocol@0.0.1367902)
       cosmiconfig: 9.0.0(typescript@5.6.3)
-      devtools-protocol: 0.0.1354347
-      puppeteer-core: 23.7.1
+      devtools-protocol: 0.0.1367902
+      puppeteer-core: 23.9.0
       typed-query-selector: 2.12.0
     transitivePeerDependencies:
       - bufferutil

--- a/src/bots/zoom/src/index.ts
+++ b/src/bots/zoom/src/index.ts
@@ -9,7 +9,7 @@ dotenv.config();
 
 // Url from Zoom meeting
 const url =
-    "https://us05web.zoom.us/j/87661417895?pwd=tjA3MYFChR5bPACMv6LYZ6kMghFRbG.1";
+    "https://us05web.zoom.us/j/84887889827?pwd=jWB1bODrre32abYKxE94bM2cFxI0Ml.1";
 
 // Parse the url to get the web meeting url
 const parseZoomUrl = (input: string): string => {
@@ -48,20 +48,7 @@ if (
   const browser = await launch({
     executablePath: puppeteer.executablePath(),
     headless: "new",
-    // slowMo: 10,
-    args: [
-        "--no-sandbox",
-    //     "--disable-setuid-sandbox",
-    //     "--disable-dev-shm-usage",
-    //     "--disable-gpu",
-        // "--use-fake-ui-for-media-stream",
-        "--use-fake-device-for-media-stream",
-        "--window-size=1920,1080",
-    //     "--disable-web-security",
-    //     "--allow-running-insecure-content",
-    //     "--autoplay-policy=no-user-gesture-required",
-    ],
-    // ignoreDefaultArgs: ["--mute-audio"],
+    args: ["--no-sandbox"],
   });
   const urlObj = new URL(parseZoomUrl(url));
 


### PR DESCRIPTION
### TL;DR
Updated Zoom bot Docker configuration to use the official Puppeteer image and upgraded dependencies. Using Rosetta emulation fixes issues.

### What changed?
- Switched base Docker image from `node:22-alpine` to `ghcr.io/puppeteer/puppeteer:latest`
- Simplified Docker configuration by removing manual Chrome dependencies
- Updated Puppeteer from v23.3.0 to v23.9.0
- Updated puppeteer-stream from v3.0.15 to v3.0.19
- Streamlined browser launch configuration by removing unnecessary arguments
- Updated test Zoom meeting URL
- Changed Docker Desktop locally to include Rosetta emulation

### How to test?
1. Build the Docker container using the updated Dockerfile
2. Run the container and verify the bot can successfully connect to Zoom meetings
3. Confirm screen recording functionality works as expected

### Why make this change?
The official Puppeteer Docker image provides a more stable and optimized environment for running headless Chrome, reducing potential compatibility issues and simplifying maintenance. The dependency updates ensure we're using the latest stable versions with bug fixes and improvements.

Completes MEE-70