### PR TITLE
feat: enhance bot schema and add user endpoints

### DIFF
--- a/src/backend/src/db/schema.ts
+++ b/src/backend/src/db/schema.ts
@@ -24,38 +24,61 @@ export const insertUserSchema = createInsertSchema(users).omit({
 export const selectUserSchema = createSelectSchema(users)
 
 export const meetingInfoSchema = z.object({
-  meetingLink: z.string().optional().describe('Meeting join URL'),
   meetingId: z.string().optional().describe('Meeting ID'),
-  passcode: z.string().optional().describe('Meeting passcode'),
-  platform: z
-    .enum(['zoom', 'teams', 'google'])
-    .optional()
-    .describe('Meeting platform'),
+  meetingPassword: z.string().optional().describe('Meeting password'),
+  meetingUrl: z.string().optional().describe('Meeting URL'),
+  organizerId: z.string().optional().describe('Organizer ID'),
+  tenantId: z.string().optional().describe('Tenant ID'),
+  messageId: z.string().optional().describe('Message ID'),
+  threadId: z.string().optional().describe('Thread ID'),
+  platform: z.enum(['zoom', 'teams', 'google']).optional().describe('Platform'),
 })
 export type MeetingInfo = z.infer<typeof meetingInfoSchema>
+
+export const deploymentStatus = z.enum([
+  'PENDING',
+  'DEPLOYING',
+  'DEPLOYED',
+  'FAILED',
+])
+export type DeploymentStatus = z.infer<typeof deploymentStatus>
 
 export const bots = pgTable('bots', {
   id: serial('id').primaryKey(),
   userId: integer('user_id')
     .references(() => users.id)
     .notNull(),
-  meetingName: varchar('meeting_name', { length: 255 }),
-  meetingInfo: json('meeting_info').$type<MeetingInfo>(),
+  meetingTitle: varchar('meeting_name', { length: 255 }),
+  meetingInfo: json('meeting_info').$type<MeetingInfo>().notNull(),
   startTime: timestamp('start_time').notNull(),
   endTime: timestamp('end_time').notNull(),
+  recording: varchar('recording', { length: 255 }),
+  lastHeartbeat: timestamp('last_heartbeat'),
   createdAt: timestamp('created_at').defaultNow(),
+  deploymentStatus: varchar('deployment_status', { length: 255 })
+    .$type<DeploymentStatus>()
+    .notNull()
+    .default('PENDING'),
+  deploymentError: varchar('deployment_error', { length: 255 }),
 })
 export const insertBotSchema = createInsertSchema(bots)
   .omit({
     id: true,
     createdAt: true,
+    recording: true,
   })
   .extend({
-    meetingInfo: meetingInfoSchema.describe('Meeting connection information'),
+    meetingInfo: meetingInfoSchema,
+    deploymentStatus: deploymentStatus,
   })
-export const selectBotSchema = createSelectSchema(bots).extend({
-  meetingInfo: meetingInfoSchema,
-})
+export const selectBotSchema = createSelectSchema(bots)
+  .omit({
+    recording: true,
+  })
+  .extend({
+    meetingInfo: meetingInfoSchema,
+    deploymentStatus: deploymentStatus,
+  })
 
 export const events = pgTable('events', {
   id: serial('id').primaryKey(),

--- a/src/backend/src/routers/bots.ts
+++ b/src/backend/src/routers/bots.ts
@@ -9,11 +9,7 @@ export const botsRouter = createTRPCRouter({
     .input(z.object({}))
     .output(z.array(selectBotSchema))
     .query(async ({ ctx }) => {
-      const result = await ctx.db.select().from(bots)
-      return result.map((bot) => ({
-        ...bot,
-        meetingInfo: bot.meetingInfo ?? {},
-      }))
+      return await ctx.db.select().from(bots)
     }),
 
   getBot: procedure
@@ -28,10 +24,7 @@ export const botsRouter = createTRPCRouter({
       if (!result[0]) {
         throw new Error('Bot not found')
       }
-      return {
-        ...result[0],
-        meetingInfo: result[0].meetingInfo ?? {},
-      }
+      return result[0]
     }),
 
   createBot: procedure
@@ -59,10 +52,7 @@ export const botsRouter = createTRPCRouter({
           throw new Error('Bot creation failed - no result returned')
         }
 
-        return {
-          ...result[0],
-          meetingInfo: result[0].meetingInfo ?? {},
-        }
+        return result[0]
       } catch (error) {
         console.error('Error creating bot:', error)
         throw error
@@ -88,10 +78,7 @@ export const botsRouter = createTRPCRouter({
       if (!result[0]) {
         throw new Error('Bot not found')
       }
-      return {
-        ...result[0],
-        meetingInfo: result[0].meetingInfo ?? {},
-      }
+      return result[0]
     }),
 
   deleteBot: procedure
@@ -108,5 +95,26 @@ export const botsRouter = createTRPCRouter({
         throw new Error('Bot not found')
       }
       return { message: 'Bot deleted successfully' }
+    }),
+
+  getRecording: procedure
+    .meta({
+      openapi: {
+        method: 'GET',
+        path: '/bots/{id}/recording',
+      },
+    })
+    .input(z.object({ id: z.number() }))
+    .output(z.object({ recording: z.string().nullable() }))
+    .query(async ({ input, ctx }) => {
+      const result = await ctx.db
+        .select({ recording: bots.recording })
+        .from(bots)
+        .where(eq(bots.id, input.id))
+
+      if (!result[0]) {
+        throw new Error('Bot not found')
+      }
+      return { recording: result[0].recording }
     }),
 })

--- a/src/backend/src/routers/users.ts
+++ b/src/backend/src/routers/users.ts
@@ -11,7 +11,7 @@ export const usersRouter = createTRPCRouter({
     .query(async ({ ctx }) => {
       return ctx.db.select().from(users)
     }),
-    
+
 
   getById: procedure
     .meta({ openapi: { method: 'GET', path: '/users/{id}' } })
@@ -31,6 +31,54 @@ export const usersRouter = createTRPCRouter({
     .output(selectUserSchema)
     .mutation(async ({ ctx, input }) => {
       const result = await ctx.db.insert(users).values(input).returning()
+      return result[0]
+    }),
+
+  updateUser: procedure
+    .meta({
+      openapi: {
+        method: 'PATCH',
+        path: '/users/{id}',
+      },
+    })
+    .input(
+      z.object({
+        id: z.number(),
+        data: insertUserSchema.partial(),
+      })
+    )
+    .output(selectUserSchema)
+    .mutation(async ({ ctx, input }) => {
+      const result = await ctx.db
+        .update(users)
+        .set(input.data)
+        .where(eq(users.id, input.id))
+        .returning()
+
+      if (!result[0]) {
+        throw new Error('User not found')
+      }
+      return result[0]
+    }),
+
+  deleteUser: procedure
+    .meta({
+      openapi: {
+        method: 'DELETE',
+        path: '/users/{id}',
+      },
+    })
+    .input(z.object({ id: z.number() }))
+    .output(selectUserSchema)
+    .mutation(async ({ ctx, input }) => {
+      const result = await ctx.db
+        .delete(users)
+        .where(eq(users.id, input.id))
+        .returning()
+
+      if (!result[0]) {
+        throw new Error('User not found')
+      }
       return result[0]
     }),
 })


### PR DESCRIPTION
### TL;DR
Enhanced bot management system with deployment tracking and expanded user management capabilities.

Deployment tracking is for #82.

### What changed?
- Added deployment status tracking (`PENDING`, `DEPLOYING`, `DEPLOYED`, `FAILED`) for bots
- Reintroduced meeting info fields: `organizerId`, `tenantId`, `messageId`, `threadId`
- Renamed `meetingLink` to `meetingUrl` and `passcode` to `meetingPassword`
- Added recording management with a new `getRecording` endpoint
- Implemented new user management endpoints: `updateUser` and `deleteUser`
- Added `lastHeartbeat` and `deploymentError` tracking for bots, heartbeat is for #83 
- Simplified bot response handling by removing unnecessary meetingInfo fallbacks