### PR TITLE
feat: add events router and schema

### DIFF
--- a/src/backend/src/routers/index.ts
+++ b/src/backend/src/routers/index.ts
@@ -1,9 +1,11 @@
 import { createTRPCRouter } from '../server/trpc.js'
 import { botsRouter } from './bots'
+import { eventsRouter } from './events'
 import { usersRouter } from './users'
 
 export const appRouter = createTRPCRouter({
   bots: botsRouter,
+  events: eventsRouter,
   users: usersRouter,
 })
 


### PR DESCRIPTION
### TL;DR
Added event tracking system with standardized event types and CRUD operations

### What changed?
- Defined structured event types with descriptions (PARTICIPANT_JOIN, PARTICIPANT_LEAVE, etc.)
- Created Zod schemas for event validation and type safety
- Added event data structures for different event types (participant data, log data, status data)
- Implemented complete CRUD API endpoints for event management:
  - GET /events
  - GET /events/bot/{botId}
  - GET /events/{id}
  - POST /events
  - PATCH /events/{id}
  - DELETE /events/{id}