### PR TITLE
feat: add bot configuration schema

### DIFF
--- a/src/backend/src/db/schema.ts
+++ b/src/backend/src/db/schema.ts
@@ -80,6 +80,44 @@ export const selectBotSchema = createSelectSchema(bots)
     deploymentStatus: deploymentStatus,
   })
 
+const silenceDetectionSchema = z.object({
+  timeout: z.number(),
+  activateAfter: z.number(),
+})
+const botDetectionSchema = z.object({
+  usingParticipantEvents: z.object({
+    timeout: z.number(),
+    activateAfter: z.number(),
+  }),
+  usingParticipantNames: z.object({
+    timeout: z.number(),
+    activateAfter: z.number(),
+  }),
+})
+const automaticLeaveSchema = z.object({
+  silenceDetection: silenceDetectionSchema,
+  botDetection: botDetectionSchema,
+  waitingRoomTimeout: z.number(),
+  noOneJoinedTimeout: z.number(),
+  everyoneLeftTimeout: z.number(),
+})
+
+export const botConfigSchema = insertBotSchema
+  .pick({
+    userId: true,
+    meetingInfo: true,
+    meetingTitle: true,
+    startTime: true,
+    endTime: true,
+  })
+  .extend({
+    botDisplayName: z.string(),
+    botImage: z.string().url(),
+    callbackUrl: z.string().url(),
+    heartbeatInterval: z.number(),
+    automaticLeave: automaticLeaveSchema,
+  })
+
 const EVENT_DESCRIPTIONS = {
   PARTICIPANT_JOIN:
     'A participant has joined the call. The data.participantId will contain the id of the participant.',


### PR DESCRIPTION
### TL;DR
Added Zod schema definitions for bot configuration and automatic leave settings, to be consistent with #77 

### What changed?
- Created new schema definitions for bot configuration validation:
  - `silenceDetectionSchema`: Defines timeout and activation parameters
  - `botDetectionSchema`: Specifies detection settings using participant events and names
  - `automaticLeaveSchema`: Combines silence detection, bot detection, and various timeout settings
  - `botConfigSchema`: Extends existing bot schema with display name, image, callback URL, heartbeat, and automatic leave settings