### PR TITLE
feat: add bot deployment endpoint

### DIFF
--- a/src/backend/src/db/schema.ts
+++ b/src/backend/src/db/schema.ts
@@ -118,6 +118,11 @@ export const botConfigSchema = insertBotSchema
     automaticLeave: automaticLeaveSchema,
   })
 
+export const deployBotInputSchema = z.object({
+  id: z.number(),
+  botConfig: botConfigSchema,
+})
+
 const EVENT_DESCRIPTIONS = {
   PARTICIPANT_JOIN:
     'A participant has joined the call. The data.participantId will contain the id of the participant.',


### PR DESCRIPTION
### TL;DR
Added a new `deployBot` endpoint to manage bot deployment status and configuration.

We will still need to figure out how to actually deploy the bots, but this is a placeholder for now.

### What changed?
- Created a new `deployBotInputSchema` to validate deployment requests
- Added a `deployBot` mutation endpoint that:
  - Updates bot status to "DEPLOYING" when started
  - Handles success by setting status to "DEPLOYED"
  - Handles failures by setting status to "FAILED" with error message
  - Returns the updated bot object

### Why make this change?
To provide a structured way to manage bot deployments and track their status, enabling better monitoring and error handling of the deployment process