### PR TITLE
feat: add bot heartbeat endpoint

### DIFF
--- a/src/backend/src/db/schema.ts
+++ b/src/backend/src/db/schema.ts
@@ -212,3 +212,8 @@ export const selectEventSchema = createSelectSchema(events).extend({
   data: eventData.nullable(),
   eventType: eventCode,
 })
+
+export const heartbeatSchema = z.object({
+  id: z.number(),
+  events: z.array(insertEventSchema.omit({ botId: true })),
+})


### PR DESCRIPTION
### TL;DR
Added a new heartbeat endpoint for bots to report their status and events

### What changed?
- Created a new `heartbeatSchema` to validate bot heartbeat requests
- Added a new `heartbeat` mutation endpoint to the bots router
- The endpoint updates the bot's `lastHeartbeat` timestamp
- Allows bots to submit events in bulk during heartbeat

Completes MEE-140