### PR TITLE
feat: integrate tRPC client in Meets bot

### DIFF
--- a/src/bots/meets/package.json
+++ b/src/bots/meets/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.697.0",
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
+    "@trpc/client": "^10.45.2",
+    "@trpc/server": "^10.45.2",
     "dotenv": "^16.4.5",
     "fs-extra": "^11.2.0",
     "playwright": "^1.49.1",
@@ -23,7 +25,8 @@
     "puppeteer": "^23.7.0",
     "puppeteer-extra": "^3.3.6",
     "puppeteer-extra-plugin-stealth": "^2.11.2",
-    "puppeteer-stream": "3.0.9"
+    "puppeteer-stream": "3.0.9",
+    "superjson": "^2.2.1"
   },
   "devDependencies": {
     "tsx": "^4.19.0",

--- a/src/bots/meets/pnpm-lock.yaml
+++ b/src/bots/meets/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@ffmpeg-installer/ffmpeg':
         specifier: ^1.1.0
         version: 1.1.0
+      '@trpc/client':
+        specifier: ^10.45.2
+        version: 10.45.2(@trpc/server@10.45.2)
+      '@trpc/server':
+        specifier: ^10.45.2
+        version: 10.45.2
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -44,6 +50,9 @@ importers:
       puppeteer-stream:
         specifier: 3.0.9
         version: 3.0.9(typescript@5.6.2)
+      superjson:
+        specifier: ^2.2.1
+        version: 2.2.2
     devDependencies:
       tsx:
         specifier: ^4.19.0
@@ -637,6 +646,14 @@ packages:
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
+  '@trpc/client@10.45.2':
+    resolution: {integrity: sha512-ykALM5kYWTLn1zYuUOZ2cPWlVfrXhc18HzBDyRhoPYN0jey4iQHEFSEowfnhg1RvYnrAVjNBgHNeSAXjrDbGwg==}
+    peerDependencies:
+      '@trpc/server': 10.45.2
+
+  '@trpc/server@10.45.2':
+    resolution: {integrity: sha512-wOrSThNNE4HUnuhJG6PfDRp4L2009KDVxsd+2VYH8ro6o/7/jwYZ8Uu5j+VaW+mOmc8EHerHzGcdbGNQSAUPgg==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -764,6 +781,10 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  copy-anything@3.0.5:
+    resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
+    engines: {node: '>=12.13'}
 
   cosmiconfig@9.0.0:
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
@@ -986,6 +1007,10 @@ packages:
   is-plain-object@2.0.4:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
     engines: {node: '>=0.10.0'}
+
+  is-what@4.1.16:
+    resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
+    engines: {node: '>=12.13'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1292,6 +1317,10 @@ packages:
 
   strnum@1.0.5:
     resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
+
+  superjson@2.2.2:
+    resolution: {integrity: sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==}
+    engines: {node: '>=16'}
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -2401,6 +2430,12 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
+  '@trpc/client@10.45.2(@trpc/server@10.45.2)':
+    dependencies:
+      '@trpc/server': 10.45.2
+
+  '@trpc/server@10.45.2': {}
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 0.7.34
@@ -2537,6 +2572,10 @@ snapshots:
   color-name@1.1.4: {}
 
   concat-map@0.0.1: {}
+
+  copy-anything@3.0.5:
+    dependencies:
+      is-what: 4.1.16
 
   cosmiconfig@9.0.0(typescript@5.6.2):
     dependencies:
@@ -2770,6 +2809,8 @@ snapshots:
   is-plain-object@2.0.4:
     dependencies:
       isobject: 3.0.1
+
+  is-what@4.1.16: {}
 
   isexe@2.0.0: {}
 
@@ -3112,6 +3153,10 @@ snapshots:
       ansi-regex: 5.0.1
 
   strnum@1.0.5: {}
+
+  superjson@2.2.2:
+    dependencies:
+      copy-anything: 3.0.5
 
   supports-color@5.5.0:
     dependencies:

--- a/src/bots/meets/src/index.ts
+++ b/src/bots/meets/src/index.ts
@@ -5,6 +5,7 @@ import dotenv from 'dotenv';
 import { setTimeout } from 'timers/promises';
 import crypto from 'crypto';
 import path from 'path';
+import { trpc } from './trpc';
 
 dotenv.config()
 
@@ -99,3 +100,14 @@ const main = (async () => {
   }
 })
 main();
+
+// trpc.bots.heartbeat
+//   .mutate({
+//     id: parseInt(process.env.BOT_ID || "0"),
+//     events: [],
+//   })
+//   .then((response) => {
+//     console.log(
+//       `[${new Date().toISOString()}] Heartbeat success: ${response.success}`
+//     );
+//   });

--- a/src/bots/meets/src/trpc.ts
+++ b/src/bots/meets/src/trpc.ts
@@ -1,0 +1,12 @@
+import { createTRPCProxyClient, httpBatchLink } from "@trpc/client";
+import { type AppRouter } from "../../../backend/src/routers";
+import superjson from "superjson";
+
+export const trpc = createTRPCProxyClient<AppRouter>({
+  transformer: superjson,
+  links: [
+    httpBatchLink({
+      url: process.env.BACKEND_URL || "http://127.0.0.1:3001/api/trpc",
+    }),
+  ],
+});


### PR DESCRIPTION
Added tRPC client integration to Meets bot for type-safety with the backend.

For now I added an example heartbeat request as a demonstration, but commented it out.

Completes MEE-132