### PR TITLE
feat:docker_github_action_meets

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -72,3 +72,66 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+  
+  meet:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract backend metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/meetingbot/bots/meet
+
+      - name: Build and push backend Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: src/bots/meets
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  zoom:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract backend metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/meetingbot/bots/zoom
+
+      - name: Build and push backend Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: src/bots/zoom
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+  


### PR DESCRIPTION
### TL;DR
Added Docker build workflows for Google Meet and Zoom bots

### What changed?
- Added new GitHub Actions workflow jobs for building and pushing Docker images for Google Meet and Zoom bots
- Each bot has its own dedicated build job with appropriate registry paths
- Configured permissions and authentication for container registry access

### How to test?
1. Push a change to the repository
2. Verify that new workflow jobs for Meet and Zoom execute successfully
3. Check the container registry for new images under:
   - `meetingbot/bots/meet`
   - `meetingbot/bots/zoom`

### Why make this change?
To enable automated Docker image builds for Google Meet and Zoom bot components, ensuring consistent deployment and versioning alongside the existing Teams bot workflow.