### PR TITLE
feat:meet_bot_can_be_kicked

### DIFF
--- a/src/bots/meets/src/index.ts
+++ b/src/bots/meets/src/index.ts
@@ -103,6 +103,11 @@ const main = (async () => {
 
   // Browser is now closed.
 
+
+  // 15 second delay
+  console.log('Waiting 3 seconds before proceeding')
+  await setTimeout(3000);
+  
   // Upload recording to S3
   console.log("Uploading recording to S3...");
   const filePath = path.resolve(__dirname, "recording.mp4");


### PR DESCRIPTION
### TL;DR
Added detection for when a bot gets kicked from a Google Meet and improved meeting exit handling.

### What changed?
- Added detection for when a bot gets kicked from a meeting using a "Return to home screen" button selector
- Implemented a continuous loop to check meeting end conditions every second
- Added proper leave button detection before attempting to click it
- Enhanced logging for better debugging
- Added a 15-second delay before proceeding with recording operations
- Improved error handling around the meeting exit process

### How to test?
1. Join a Google Meet with the bot
2. Have a host kick the bot from the meeting
3. Verify the bot detects being kicked and exits gracefully
4. Check that recordings are properly saved
5. Verify the bot properly exits when it's the last person in the meeting

### Why make this change?
Previously, the bot could not detect when it was kicked from a meeting, which could lead to hanging processes and incomplete recordings. This change ensures the bot can handle all meeting exit scenarios gracefully, including being kicked by a host, while maintaining proper recording management.