### PR TITLE
refactor: remove config and env files from Dockerfiles

### DIFF
--- a/src/bots/meets/Dockerfile
+++ b/src/bots/meets/Dockerfile
@@ -46,8 +46,6 @@ COPY --from=base /root/.cache/ms-playwright /root/.cache/ms-playwright
 
 # Copy files into the container
 COPY ./src ./src
-COPY .env ./
-COPY config.json ./
 
 #Run Commsand
 CMD ["sh", "-c", "xvfb-run -s '-screen 0 1280x1024x24' npm run dev"]

--- a/src/bots/teams/Dockerfile
+++ b/src/bots/teams/Dockerfile
@@ -15,7 +15,7 @@ USER $PPTRUSER_UID
 WORKDIR /home/pptruser
 
 # Copy the required files into the src directory
-COPY package.json config.json pnpm-lock.yaml .env ./
+COPY package.json pnpm-lock.yaml ./
 COPY src/index.ts ./src/
 
 # Install dependencies inside the container

--- a/src/bots/zoom/Dockerfile
+++ b/src/bots/zoom/Dockerfile
@@ -15,7 +15,7 @@ USER $PPTRUSER_UID
 WORKDIR /home/pptruser
 
 # Copy the required files into the src directory
-COPY package.json config.json pnpm-lock.yaml .env ./
+COPY package.json pnpm-lock.yaml ./
 COPY src/index.ts ./src/
 
 # Install dependencies inside the container


### PR DESCRIPTION
### TL;DR
Removed `.env` and `config.json` file copying from Docker configurations across meeting platform bots.

### What changed?
- Removed `COPY .env ./` and `COPY config.json ./` from all the bots in the Dockerfile

### How to test?
1. Build Docker images for each bot (meets, teams, zoom)
2. Verify that the containers start successfully without the .env and config files
3. Confirm that environment variables and configuration can be properly injected at runtime

### Why make this change?
Environment variables and configuration should be injected at runtime rather than baked into the Docker image for better security practices and flexibility across different deployment environments. This change prevents sensitive information from being included in the Docker image layers.