### PR TITLE
fix: tRPC config fix

### DIFF
--- a/src/frontend/.env.example
+++ b/src/frontend/.env.example
@@ -9,15 +9,5 @@
 # When adding additional environment variables, the schema in "/src/env.js"
 # should be updated accordingly.
 
-# Next Auth
-# You can generate a new secret on the command line with:
-# npx auth secret
-# https://next-auth.js.org/configuration/options#secret
-AUTH_SECRET=""
-
-# Next Auth Github Provider
-AUTH_GITHUB_ID=""
-AUTH_GITHUB_SECRET=""
-
-# Drizzle
-DATABASE_URL="postgresql://postgres:password@localhost:5432/meetingbot-frontend"
+DATABASE_URL=""
+BACKEND_URL="http://127.0.0.1:3001/api/trpc"

--- a/src/frontend/src/app/page.tsx
+++ b/src/frontend/src/app/page.tsx
@@ -3,9 +3,7 @@ import Link from "next/link";
 import { trpcVanilla } from "~/trpc/trpc-vanilla";
 
 export default async function Home() {
-  const bot = await trpcVanilla.bots.getBot.query({
-    id: 2,
-  });
+  const bots = await trpcVanilla.bots.getBots.query({});
 
   return (
     <>
@@ -39,9 +37,9 @@ export default async function Home() {
             </Link>
           </div>
           <div className="flex flex-col items-center gap-2">
-            {bot ? (
+            {bots[0] ? (
               <pre className="whitespace-pre-wrap rounded-lg bg-white/10 p-4">
-                {JSON.stringify(bot, null, 2)}
+                {JSON.stringify(bots[0], null, 2)}
               </pre>
             ) : (
               "Loading tRPC query..."

--- a/src/frontend/src/env.js
+++ b/src/frontend/src/env.js
@@ -7,16 +7,10 @@ export const env = createEnv({
    * isn't built with invalid env vars.
    */
   server: {
-    AUTH_SECRET:
-      process.env.NODE_ENV === "production"
-        ? z.string()
-        : z.string().optional(),
-    // AUTH_GITHUB_ID: z.string(),
-    // AUTH_GITHUB_SECRET: z.string(),
-    DATABASE_URL: z.string().url(),
     NODE_ENV: z
       .enum(["development", "test", "production"])
       .default("development"),
+    DATABASE_URL: z.string().url(),
     BACKEND_URL: z.string().url(),
   },
 
@@ -34,11 +28,8 @@ export const env = createEnv({
    * middlewares) or client-side so we need to destruct manually.
    */
   runtimeEnv: {
-    AUTH_SECRET: process.env.AUTH_SECRET,
-    // AUTH_GITHUB_ID: process.env.AUTH_GITHUB_ID,
-    // AUTH_GITHUB_SECRET: process.env.AUTH_GITHUB_SECRET,
-    DATABASE_URL: process.env.DATABASE_URL,
     NODE_ENV: process.env.NODE_ENV,
+    DATABASE_URL: process.env.DATABASE_URL,
     BACKEND_URL: process.env.BACKEND_URL,
   },
   /**

--- a/src/frontend/src/trpc/trpc-react.tsx
+++ b/src/frontend/src/trpc/trpc-react.tsx
@@ -21,14 +21,6 @@ function getQueryClient() {
   // Browser: use singleton pattern to keep the same query client
   return (clientQueryClientSingleton ??= makeQueryClient());
 }
-function getUrl() {
-  const base = (() => {
-    if (typeof window !== "undefined") return "";
-    if (process.env.BACKEND_URL) return `https://${process.env.BACKEND_URL}`;
-    return "http://127.0.0.1:8000/api/trpc";
-  })();
-  return `${base}/api/trpc`;
-}
 export function TRPCProvider(
   props: Readonly<{
     children: React.ReactNode;
@@ -44,7 +36,7 @@ export function TRPCProvider(
       transformer: superjson,
       links: [
         httpBatchLink({
-          url: getUrl(),
+          url: process.env.BACKEND_URL ?? "http://127.0.0.1:3001/api/trpc",
         }),
       ],
     }),

--- a/src/frontend/src/trpc/trpc-vanilla.tsx
+++ b/src/frontend/src/trpc/trpc-vanilla.tsx
@@ -6,7 +6,7 @@ export const trpcVanilla = createTRPCProxyClient<AppRouter>({
   transformer: superjson,
   links: [
     httpBatchLink({
-      url: process.env.BACKEND_URL ?? "http://127.0.0.1:8000/api/trpc",
+      url: process.env.BACKEND_URL ?? "http://127.0.0.1:3001/api/trpc",
       // You can pass any HTTP headers you wish here
       // async headers() {
       //   return {


### PR DESCRIPTION
### TL;DR
Updated environment configuration and tRPC client setup to properly connect with the backend service.

### What changed?
- Simplified `.env.example` by removing unused auth variables and adding `BACKEND_URL`
- Updated the homepage to fetch all bots instead of a single bot with ID 2
- Standardized the backend URL to use port 3001 across tRPC clients
- Removed redundant URL generation logic in favor of direct environment variable usage
- Streamlined environment variable validation in `env.js`

### How to test?
1. Copy `.env.example` to `.env`
2. Set your `DATABASE_URL` and verify `BACKEND_URL` points to your backend service
3. Start the frontend application
4. Verify the homepage loads and displays the first bot in the list
5. Confirm tRPC requests are successfully reaching the backend at port 3001