### PR TITLE
fix: meets recording fix + disable bot video & audio

### DIFF
--- a/src/bots/meets/src/bot.ts
+++ b/src/bots/meets/src/bot.ts
@@ -66,6 +66,9 @@ export class MeetingBot {
             '--disable-features=IsolateOrigins,site-per-process',
             '--disable-infobars',
             "--use-fake-device-for-media-stream",
+            "--use-fake-ui-for-media-stream",
+            "--use-file-for-fake-video-capture=/dev/null",
+            "--use-file-for-fake-audio-capture=/dev/null",
             ...(botSettings?.additionalBrowserSettings ?? [])
         ]
 
@@ -266,7 +269,7 @@ export class MeetingBot {
     async leaveMeeting() {
 
         // Ensure
-        this.stopRecording();
+        await this.stopRecording();
 
         // Try and Find the leave button, press. Otherwise, just delete the browser.
         await this.page.click(leaveButton);


### PR DESCRIPTION
### TL;DR
Added fake media stream handling and fixed async recording cleanup in the Meeting Bot

### What changed?
- Added Chrome flags to handle fake media streams for audio and video
- Added null device paths for fake audio and video capture
- Made `stopRecording()` call in `leaveMeeting()` await properly

### How to test?
1. Start a meeting with the bot
2. Verify the bot joins without media permission prompts
3. Leave the meeting and confirm recording stops cleanly
4. Check that no media permission dialogs appear during the session

### Why make this change?
The bot should not show any video or audio.