### PR TITLE
feat:meet_recording_switch

### DIFF
--- a/src/bots/meets/.gitignore
+++ b/src/bots/meets/.gitignore
@@ -1,0 +1,2 @@
+/tmp
+/tmp/debug.png

--- a/src/bots/meets/package.json
+++ b/src/bots/meets/package.json
@@ -24,7 +24,6 @@
     "playwright": "^1.49.1",
     "playwright-extra": "^4.3.6",
     "playwright-extra-plugin-stealth": "^0.0.1",
-    "playwright-video": "^2.4.0",
     "puppeteer": "^23.7.0",
     "puppeteer-extra": "^3.3.6",
     "puppeteer-extra-plugin-stealth": "^2.11.2",

--- a/src/bots/meets/pnpm-lock.yaml
+++ b/src/bots/meets/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       playwright-extra-plugin-stealth:
         specifier: ^0.0.1
         version: 0.0.1
-      playwright-video:
-        specifier: ^2.4.0
-        version: 2.4.0
       puppeteer:
         specifier: ^23.7.0
         version: 23.9.0(typescript@5.6.2)
@@ -1163,10 +1160,6 @@ packages:
         optional: true
       playwright-core:
         optional: true
-
-  playwright-video@2.4.0:
-    resolution: {integrity: sha512-NA4ND29uaMEy78wXepH0dS2UnFd/GxSoScyoViql8mv5jpkEPHJPqxBKTO8l3rYbbDfFqrP/vQUPmsCB1UNXng==}
-    engines: {node: '>=10.15.0'}
 
   playwright@1.49.1:
     resolution: {integrity: sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==}
@@ -2954,16 +2947,6 @@ snapshots:
     optionalDependencies:
       playwright: 1.49.1
       playwright-core: 1.49.1
-    transitivePeerDependencies:
-      - supports-color
-
-  playwright-video@2.4.0:
-    dependencies:
-      debug: 4.3.7
-      fluent-ffmpeg: 2.1.3
-      fs-extra: 9.1.0
-      playwright-core: 1.49.1
-      tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 

--- a/src/bots/meets/src/index.ts
+++ b/src/bots/meets/src/index.ts
@@ -37,7 +37,7 @@ const main = (async () => {
   console.log('Received bot data:', botData)
   const botId = botData.id;
   const url = botData.meetingInfo.meetingUrl!;
-  const recordingPath = "./recording.mp4";
+  const recordingPath = path.resolve("./recording.mp4");
   const awsAccessKeyId = process.env.AWS_ACCESS_KEY_ID!
   const awsSecretAccessKey = process.env.AWS_SECRET_ACCESS_KEY!
   const awsBucketName = process.env.AWS_BUCKET_NAME!


### PR DESCRIPTION
### TL;DR
Replaced Playwright video recording with native browser MediaRecorder API for Google Meet recordings

I wish awful things upon Playwright-Video

### What changed?
- Removed `playwright-video` dependency and related code
- Implemented browser-native MediaRecorder API for screen capture
- Added audio recording configuration to capture system audio only
- Implemented chunk-based recording buffer system
- Added camera and microphone auto-mute functionality
- Added new browser flags for media permissions
- Created `.gitignore` for temporary files

### How to test?
1. Join a Google Meet call using the bot
2. Verify that camera and microphone are automatically disabled
3. Confirm recording starts automatically
4. Check that the recording saves properly when the meeting ends
5. Verify the output video contains system audio without microphone input

### Why make this change?
The previous Playwright-based recording solution was unreliable and resource-intensive. The native MediaRecorder API provides better performance, more reliable recording capabilities, and proper system audio capture while reducing dependencies and resource usage.