### PR TITLE
feat:deploy_backend_on_windows

### DIFF
--- a/src/backend/src/services/botDeployment.ts
+++ b/src/backend/src/services/botDeployment.ts
@@ -53,15 +53,27 @@ export async function deployBot({
       automaticLeave: bot.automaticLeave,
     }
 
-    // Spawn the bot process
-    const botProcess = spawn('pnpm', ['dev'], {
-      cwd: meetsDir,
-      env: {
-        ...process.env,
-        BOT_DATA: JSON.stringify(config),
-      },
-    })
 
+    let botProcess = null;
+    // Windows Process
+    if (/^win/.test(process.platform) ) {
+      botProcess = botProcess = spawn('cmd', ['/c', 'pnpm', 'dev'], {
+        cwd: meetsDir,
+        env: {
+          ...process.env,
+          BOT_DATA: JSON.stringify(config),
+        },
+      });
+    // UNIX Process
+    } else {
+      botProcess = spawn('pnpm', ['dev'], {
+        cwd: meetsDir,
+        env: {
+          ...process.env,
+          BOT_DATA: JSON.stringify(config),
+        },
+      });
+    }
     // Log output for debugging
     botProcess.stdout.on('data', (data) => {
       console.log(`Bot ${botId} stdout: ${data}`)

--- a/src/bots/meets/.gitignore
+++ b/src/bots/meets/.gitignore
@@ -1,0 +1,2 @@
+/tmp
+/tmp/debug.png

--- a/src/bots/meets/package.json
+++ b/src/bots/meets/package.json
@@ -24,7 +24,6 @@
     "playwright": "^1.49.1",
     "playwright-extra": "^4.3.6",
     "playwright-extra-plugin-stealth": "^0.0.1",
-    "playwright-video": "^2.4.0",
     "puppeteer": "^23.7.0",
     "puppeteer-extra": "^3.3.6",
     "puppeteer-extra-plugin-stealth": "^2.11.2",

--- a/src/bots/meets/pnpm-lock.yaml
+++ b/src/bots/meets/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       playwright-extra-plugin-stealth:
         specifier: ^0.0.1
         version: 0.0.1
-      playwright-video:
-        specifier: ^2.4.0
-        version: 2.4.0
       puppeteer:
         specifier: ^23.7.0
         version: 23.9.0(typescript@5.6.2)
@@ -1163,10 +1160,6 @@ packages:
         optional: true
       playwright-core:
         optional: true
-
-  playwright-video@2.4.0:
-    resolution: {integrity: sha512-NA4ND29uaMEy78wXepH0dS2UnFd/GxSoScyoViql8mv5jpkEPHJPqxBKTO8l3rYbbDfFqrP/vQUPmsCB1UNXng==}
-    engines: {node: '>=10.15.0'}
 
   playwright@1.49.1:
     resolution: {integrity: sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==}
@@ -2954,16 +2947,6 @@ snapshots:
     optionalDependencies:
       playwright: 1.49.1
       playwright-core: 1.49.1
-    transitivePeerDependencies:
-      - supports-color
-
-  playwright-video@2.4.0:
-    dependencies:
-      debug: 4.3.7
-      fluent-ffmpeg: 2.1.3
-      fs-extra: 9.1.0
-      playwright-core: 1.49.1
-      tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 

--- a/src/bots/meets/src/index.ts
+++ b/src/bots/meets/src/index.ts
@@ -37,7 +37,7 @@ const main = (async () => {
   console.log('Received bot data:', botData)
   const botId = botData.id;
   const url = botData.meetingInfo.meetingUrl!;
-  const recordingPath = "./recording.mp4";
+  const recordingPath = path.resolve("./recording.mp4");
   const awsAccessKeyId = process.env.AWS_ACCESS_KEY_ID!
   const awsSecretAccessKey = process.env.AWS_SECRET_ACCESS_KEY!
   const awsBucketName = process.env.AWS_BUCKET_NAME!

--- a/src/bots/meets/src/index.ts
+++ b/src/bots/meets/src/index.ts
@@ -112,19 +112,18 @@ const main = (async () => {
   console.log('Waiting 1 second before proceeding (ensure recording is unlocked)')
   await setTimeout(1000);
   
-  // Upload recording to S3
+  // Upload recording to S3 in the correct format
   console.log("Uploading recording to S3...");
-  const filePath = path.resolve(__dirname, "recording.mp4");
   const fileContent = readFileSync(recordingPath);
   const uuid = crypto.randomUUID();
-  const key = `recordings/${uuid}-meets-recording.mp4`;
+  const key = `recordings/${uuid}-meet.webm`;
 
   try {
     const commandObjects = {
       Bucket: awsBucketName,
       Key: key,
       Body: fileContent,
-      ContentType: 'video/mp4',
+      ContentType: 'video/webm',
     };
 
     const putCommand = new PutObjectCommand(commandObjects);


### PR DESCRIPTION
### TL;DR
Added Windows support for bot deployment process spawning

### What changed?
Added conditional logic to use `cmd /c` prefix when spawning bot processes on Windows systems, while maintaining the existing UNIX process spawning method for other platforms

### How to test?
1. Deploy a bot on a Windows machine
2. Verify the bot process starts successfully
3. Confirm bot functionality works as expected
4. Test the same deployment on a UNIX-based system to ensure existing functionality is preserved

### Why make this change?
The previous implementation only supported UNIX-based systems for bot deployment. This change ensures compatibility with Windows environments, allowing the bot deployment service to work across all major operating systems.