### PR TITLE
feat: add API key authentication and request logging

### DIFF
--- a/src/backend/request_testing.http
+++ b/src/backend/request_testing.http
@@ -45,3 +45,23 @@ content-type: application/json
     "waitingRoomTimeout": 180000
   }
 }
+
+###
+
+# Create an API key
+POST http://127.0.0.1:3001/api/api-keys
+content-type: application/json
+
+{
+  "name": "Test API Key",
+  "userId": 5
+}
+
+### 
+
+# Get bots
+GET http://127.0.0.1:3001/api/bots
+content-type: application/json
+x-api-key: 1ba6e028b7f9354ace5011bf5406ce61d1da8870644230c69589b45e2dd5f1cc
+
+

--- a/src/backend/src/db/migrations/0001_new_snowbird.sql
+++ b/src/backend/src/db/migrations/0001_new_snowbird.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "api_keys" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"key" varchar(64) NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"created_at" timestamp DEFAULT now(),
+	"last_used_at" timestamp,
+	"expires_at" timestamp,
+	"is_revoked" boolean DEFAULT false,
+	CONSTRAINT "api_keys_key_unique" UNIQUE("key")
+);
+--> statement-breakpoint
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/src/backend/src/db/migrations/0002_fast_phil_sheldon.sql
+++ b/src/backend/src/db/migrations/0002_fast_phil_sheldon.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "api_request_logs" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"api_key_id" integer NOT NULL,
+	"user_id" integer NOT NULL,
+	"method" varchar(10) NOT NULL,
+	"path" varchar(255) NOT NULL,
+	"status_code" integer NOT NULL,
+	"request_body" json,
+	"response_body" json,
+	"error" varchar(1024),
+	"duration" integer NOT NULL,
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE "api_request_logs" ADD CONSTRAINT "api_request_logs_api_key_id_api_keys_id_fk" FOREIGN KEY ("api_key_id") REFERENCES "public"."api_keys"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "api_request_logs" ADD CONSTRAINT "api_request_logs_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/src/backend/src/db/migrations/meta/0001_snapshot.json
+++ b/src/backend/src/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,325 @@
+{
+  "id": "4ea8a27b-a079-4293-b2e4-16b9b30624a2",
+  "prevId": "b669127d-9afc-4144-8963-ac7801e5616c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_revoked": {
+          "name": "is_revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bots": {
+      "name": "bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bot_display_name": {
+          "name": "bot_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_image": {
+          "name": "bot_image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_name": {
+          "name": "meeting_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_info": {
+          "name": "meeting_info",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recording": {
+          "name": "recording",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat": {
+          "name": "last_heartbeat",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'READY_TO_DEPLOY'"
+        },
+        "deployment_error": {
+          "name": "deployment_error",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_interval": {
+          "name": "heartbeat_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automatic_leave": {
+          "name": "automatic_leave",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bots_user_id_users_id_fk": {
+          "name": "bots_user_id_users_id_fk",
+          "tableFrom": "bots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_bot_id_bots_id_fk": {
+          "name": "events_bot_id_bots_id_fk",
+          "tableFrom": "events",
+          "tableTo": "bots",
+          "columnsFrom": [
+            "bot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/backend/src/db/migrations/meta/0002_snapshot.json
+++ b/src/backend/src/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,432 @@
+{
+  "id": "be5d7855-a258-4736-8f4e-893f24576a29",
+  "prevId": "4ea8a27b-a079-4293-b2e4-16b9b30624a2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_revoked": {
+          "name": "is_revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_request_logs": {
+      "name": "api_request_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_request_logs_api_key_id_api_keys_id_fk": {
+          "name": "api_request_logs_api_key_id_api_keys_id_fk",
+          "tableFrom": "api_request_logs",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "api_request_logs_user_id_users_id_fk": {
+          "name": "api_request_logs_user_id_users_id_fk",
+          "tableFrom": "api_request_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bots": {
+      "name": "bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bot_display_name": {
+          "name": "bot_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_image": {
+          "name": "bot_image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_name": {
+          "name": "meeting_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_info": {
+          "name": "meeting_info",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recording": {
+          "name": "recording",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat": {
+          "name": "last_heartbeat",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'READY_TO_DEPLOY'"
+        },
+        "deployment_error": {
+          "name": "deployment_error",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_interval": {
+          "name": "heartbeat_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automatic_leave": {
+          "name": "automatic_leave",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bots_user_id_users_id_fk": {
+          "name": "bots_user_id_users_id_fk",
+          "tableFrom": "bots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_bot_id_bots_id_fk": {
+          "name": "events_bot_id_bots_id_fk",
+          "tableFrom": "events",
+          "tableTo": "bots",
+          "columnsFrom": [
+            "bot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/backend/src/db/migrations/meta/_journal.json
+++ b/src/backend/src/db/migrations/meta/_journal.json
@@ -8,6 +8,20 @@
       "when": 1738962057115,
       "tag": "0000_chief_rage",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1739803274238,
+      "tag": "0001_new_snowbird",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1739804379486,
+      "tag": "0002_fast_phil_sheldon",
+      "breakpoints": true
     }
   ]
 }

--- a/src/backend/src/routers/apiKeys.ts
+++ b/src/backend/src/routers/apiKeys.ts
@@ -1,0 +1,207 @@
+import { z } from 'zod'
+import { createTRPCRouter, protectedProcedure, procedure } from '../server/trpc'
+import {
+  apiKeys,
+  insertApiKeySchema,
+  selectApiKeySchema,
+  apiRequestLogs,
+  selectApiRequestLogSchema,
+} from '../db/schema'
+import { eq, desc, sql, inArray } from 'drizzle-orm'
+import { randomBytes } from 'crypto'
+
+export const apiKeysRouter = createTRPCRouter({
+  createApiKey: procedure
+    .meta({
+      openapi: {
+        method: 'POST',
+        path: '/api-keys',
+        description: 'Create a new API key for the specified user',
+      },
+    })
+    .input(insertApiKeySchema)
+    .output(
+      selectApiKeySchema.extend({
+        key: z.string(),
+      })
+    )
+    .mutation(async ({ input, ctx }) => {
+      // Generate a random API key
+      const key = randomBytes(32).toString('hex')
+
+      const result = await ctx.db
+        .insert(apiKeys)
+        .values({
+          ...input,
+          key,
+        })
+        .returning()
+
+      if (!result[0]) {
+        throw new Error('Failed to create API key')
+      }
+
+      return result[0]
+    }),
+
+  listApiKeys: protectedProcedure
+    .meta({
+      openapi: {
+        method: 'GET',
+        path: '/api-keys',
+        description: 'List all API keys for the specified user',
+      },
+    })
+    .input(z.object({}))
+    .output(z.array(selectApiKeySchema))
+    .query(async ({ ctx }) => {
+      return await ctx.db
+        .select()
+        .from(apiKeys)
+        .where(eq(apiKeys.userId, ctx.auth.userId))
+    }),
+
+  revokeApiKey: protectedProcedure
+    .meta({
+      openapi: {
+        method: 'POST',
+        path: '/api-keys/{id}/revoke',
+        description: 'Revoke an API key',
+      },
+    })
+    .input(z.object({ id: z.number() }))
+    .output(selectApiKeySchema)
+    .mutation(async ({ input, ctx }) => {
+      // Check if the API key belongs to the user
+      const apiKey = await ctx.db
+        .select()
+        .from(apiKeys)
+        .where(eq(apiKeys.id, input.id))
+
+      if (!apiKey[0] || apiKey[0].userId !== ctx.auth.userId) {
+        throw new Error('API key not found')
+      }
+
+      const result = await ctx.db
+        .update(apiKeys)
+        .set({ isRevoked: true })
+        .where(eq(apiKeys.id, input.id))
+        .returning()
+
+      if (!result[0]) {
+        throw new Error('API key not found')
+      }
+
+      return result[0]
+    }),
+
+  getApiKeyLogs: protectedProcedure
+    .meta({
+      openapi: {
+        method: 'GET',
+        path: '/api-keys/{id}/logs',
+        description: 'Get usage logs for a specific API key',
+      },
+    })
+    .input(
+      z.object({
+        id: z.number(),
+        limit: z.number().min(1).max(100).default(50),
+        offset: z.number().min(0).default(0),
+      })
+    )
+    .output(
+      z.object({
+        logs: z.array(selectApiRequestLogSchema),
+        total: z.number(),
+      })
+    )
+    .query(async ({ input, ctx }) => {
+      // Check if the API key belongs to the user
+      const apiKey = await ctx.db
+        .select()
+        .from(apiKeys)
+        .where(eq(apiKeys.id, input.id))
+
+      if (!apiKey[0] || apiKey[0].userId !== ctx.auth.userId) {
+        throw new Error('API key not found')
+      }
+
+      // Get logs with pagination
+      const logs = await ctx.db
+        .select()
+        .from(apiRequestLogs)
+        .where(eq(apiRequestLogs.apiKeyId, input.id))
+        .orderBy(desc(apiRequestLogs.createdAt))
+        .limit(input.limit)
+        .offset(input.offset)
+
+      // Get total count
+      const [{ count }] = await ctx.db
+        .select({ count: sql<number>`count(*)` })
+        .from(apiRequestLogs)
+        .where(eq(apiRequestLogs.apiKeyId, input.id))
+
+      return {
+        logs,
+        total: count,
+      }
+    }),
+
+  getAllApiKeyLogs: protectedProcedure
+    .meta({
+      openapi: {
+        method: 'GET',
+        path: '/api-keys/logs',
+        description: 'Get usage logs for all API keys owned by the user',
+      },
+    })
+    .input(
+      z.object({
+        limit: z.number().min(1).max(100).default(50),
+        offset: z.number().min(0).default(0),
+      })
+    )
+    .output(
+      z.object({
+        logs: z.array(selectApiRequestLogSchema),
+        total: z.number(),
+      })
+    )
+    .query(async ({ input, ctx }) => {
+      // Get all API key IDs for the user
+      const userApiKeys = await ctx.db
+        .select()
+        .from(apiKeys)
+        .where(eq(apiKeys.userId, ctx.auth.userId))
+
+      const apiKeyIds = userApiKeys.map((key) => key.id)
+
+      if (apiKeyIds.length === 0) {
+        return {
+          logs: [],
+          total: 0,
+        }
+      }
+
+      // Get logs with pagination
+      const logs = await ctx.db
+        .select()
+        .from(apiRequestLogs)
+        .where(inArray(apiRequestLogs.apiKeyId, apiKeyIds))
+        .orderBy(desc(apiRequestLogs.createdAt))
+        .limit(input.limit)
+        .offset(input.offset)
+
+      // Get total count
+      const [{ count }] = await ctx.db
+        .select({ count: sql<number>`count(*)` })
+        .from(apiRequestLogs)
+        .where(inArray(apiRequestLogs.apiKeyId, apiKeyIds))
+
+      return {
+        logs,
+        total: count,
+      }
+    }),
+}) 

--- a/src/backend/src/routers/index.ts
+++ b/src/backend/src/routers/index.ts
@@ -2,11 +2,13 @@ import { createTRPCRouter } from '../server/trpc.js'
 import { botsRouter } from './bots'
 import { eventsRouter } from './events'
 import { usersRouter } from './users'
+import { apiKeysRouter } from './apiKeys'
 
 export const appRouter = createTRPCRouter({
   bots: botsRouter,
   events: eventsRouter,
   users: usersRouter,
+  apiKeys: apiKeysRouter,
 })
 
 export type AppRouter = typeof appRouter

--- a/src/backend/src/routers/users.ts
+++ b/src/backend/src/routers/users.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod'
-import { createTRPCRouter, procedure } from '../server/trpc'
+import { createTRPCRouter, protectedProcedure } from '../server/trpc'
 import { users, insertUserSchema, selectUserSchema } from '../db/schema'
 import { eq } from 'drizzle-orm'
 
 export const usersRouter = createTRPCRouter({
-  getUsers: procedure
+  getUsers: protectedProcedure
     .meta({
       openapi: {
         method: 'GET',
@@ -18,7 +18,7 @@ export const usersRouter = createTRPCRouter({
       return ctx.db.select().from(users)
     }),
 
-  getUser: procedure
+  getUser: protectedProcedure
     .meta({
       openapi: {
         method: 'GET',
@@ -39,7 +39,7 @@ export const usersRouter = createTRPCRouter({
       return result[0]
     }),
 
-  createUser: procedure
+  createUser: protectedProcedure
     .meta({
       openapi: {
         method: 'POST',
@@ -57,7 +57,7 @@ export const usersRouter = createTRPCRouter({
       return result[0]
     }),
 
-  updateUser: procedure
+  updateUser: protectedProcedure
     .meta({
       openapi: {
         method: 'PATCH',
@@ -85,7 +85,7 @@ export const usersRouter = createTRPCRouter({
       return result[0]
     }),
 
-  deleteUser: procedure
+  deleteUser: protectedProcedure
     .meta({
       openapi: {
         method: 'DELETE',

--- a/src/backend/src/server/trpc.ts
+++ b/src/backend/src/server/trpc.ts
@@ -7,15 +7,20 @@ import superjson from 'superjson'
 import { ZodError } from 'zod'
 import { OpenApiMeta } from 'trpc-openapi'
 import { db } from '../db'
+import { CreateExpressContextOptions } from '@trpc/server/adapters/express'
+import { TRPCError } from '@trpc/server'
+import { apiKeys, apiRequestLogs } from '../db/schema'
+import { eq, and } from 'drizzle-orm'
 
-export const createTRPCContext = async () =>
-  //   {
-  //   req,
-  //   res,
-  // }: CreateExpressContextOptions
-  {
-    return { db }
+export const createTRPCContext = async ({
+  req,
+}: CreateExpressContextOptions) => {
+  return {
+    db,
+    headers: req.headers,
+    req,
   }
+}
 
 export type Context = Awaited<ReturnType<typeof createTRPCContext>>
 
@@ -66,3 +71,96 @@ export const createTRPCRouter = t.router
  * are logged in.
  */
 export const procedure = t.procedure
+
+// Create a middleware that checks for a valid API key and logs the request
+const apiKeyMiddleware = t.middleware(async ({ ctx, next, path, type }) => {
+  const startTime = Date.now()
+  const apiKey = ctx.headers['x-api-key']
+  let apiKeyRecord = null
+  let error = null
+  let statusCode = 200
+
+  try {
+    if (!apiKey || typeof apiKey !== 'string') {
+      throw new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: 'API key is required',
+      })
+    }
+
+    // Check if the API key exists and is not revoked
+    const apiKeyResult = await ctx.db
+      .select()
+      .from(apiKeys)
+      .where(and(eq(apiKeys.key, apiKey), eq(apiKeys.isRevoked, false)))
+
+    if (!apiKeyResult[0]) {
+      throw new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: 'Invalid API key',
+      })
+    }
+
+    apiKeyRecord = apiKeyResult[0]
+
+    // Update last used timestamp
+    await ctx.db
+      .update(apiKeys)
+      .set({ lastUsedAt: new Date() })
+      .where(eq(apiKeys.id, apiKeyRecord.id))
+
+    // Call the next middleware/procedure
+    const result = await next({
+      ctx: {
+        ...ctx,
+        auth: {
+          userId: apiKeyRecord.userId,
+        },
+      },
+    })
+
+    return result
+  } catch (e) {
+    error = e instanceof Error ? e.message : 'Unknown error'
+    statusCode =
+      e instanceof TRPCError
+        ? {
+            BAD_REQUEST: 400,
+            PARSE_ERROR: 400,
+            UNAUTHORIZED: 401,
+            FORBIDDEN: 403,
+            NOT_FOUND: 404,
+            METHOD_NOT_SUPPORTED: 405,
+            TIMEOUT: 408,
+            CONFLICT: 409,
+            PRECONDITION_FAILED: 412,
+            PAYLOAD_TOO_LARGE: 413,
+            UNPROCESSABLE_CONTENT: 422,
+            TOO_MANY_REQUESTS: 429,
+            CLIENT_CLOSED_REQUEST: 499,
+            INTERNAL_SERVER_ERROR: 500,
+            NOT_IMPLEMENTED: 501,
+          }[e.code] || 500
+        : 500
+    throw e
+  } finally {
+    // Log the request
+    if (apiKeyRecord) {
+      const duration = Date.now() - startTime
+      await ctx.db.insert(apiRequestLogs).values({
+        apiKeyId: apiKeyRecord.id,
+        userId: apiKeyRecord.userId,
+        method: type,
+        path,
+        statusCode,
+        requestBody: null,
+        responseBody: null, // We don't log response bodies for privacy/security
+        error,
+        duration,
+      })
+    }
+  }
+})
+
+// Export a protected procedure that requires an API key
+export const protectedProcedure = t.procedure.use(apiKeyMiddleware)


### PR DESCRIPTION
### TL;DR
Added API key authentication and request logging system for secure API access.

Btw there's fields for request and response bodies just in case for the future (maybe we want to log just if there's an error) but for now they're just always null.

https://github.com/user-attachments/assets/909c0149-77c3-421c-bd48-ca522279941a

completes MEE-155, completes MEE-156, completes MEE-101, completes MEE-157

### What changed?
- Created new database tables for API keys and request logs
- Added API key middleware for authentication
- Converted public procedures to protected procedures requiring API key authentication
- Implemented API key management endpoints (create, list, revoke)
- Added request logging for all API calls
- Added user ownership validation for all protected endpoints

### How to test?
1. Create an API key using the `/api/api-keys` endpoint
2. Use the API key in the `x-api-key` header for subsequent requests
3. Test protected endpoints (bots, events, users)
4. Verify request logs are created in the database
5. Try accessing endpoints without an API key to confirm authentication
6. Test revoking an API key and verify it no longer works

### Why make this change?
To enhance security and monitoring capabilities by:
- Ensuring only authenticated users can access the API
- Tracking API usage and detecting potential abuse
- Providing users with the ability to manage their own API access
- Creating an audit trail of all API interactions
- Enforcing proper access controls on user resources