### PR TITLE
feat: add express auth js to allow backend access via sessions alongside api keys

### DIFF
--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -1,3 +1,7 @@
 DATABASE_URL="postgres://user:password@host:5432/dbname?sslmode=require"
 NODE_ENV="development"
 PORT=3001
+AUTH_GITHUB_ID="your_github_client_id"
+AUTH_GITHUB_SECRET="your_github_client_secret"
+AUTH_SECRET="your-secret-key-here"  # Added by `npx auth`. Read more: https://cli.authjs.dev
+FRONTEND_URL="http://localhost:3000"

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -21,6 +21,8 @@
   "keywords": [],
   "author": "",
   "dependencies": {
+    "@auth/drizzle-adapter": "^1.7.4",
+    "@auth/express": "^0.8.4",
     "@trpc/server": "^10.45.2",
     "@types/lodash-es": "^4.17.12",
     "aws-sdk": "^2.1692.0",

--- a/src/backend/pnpm-lock.yaml
+++ b/src/backend/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@auth/drizzle-adapter':
+        specifier: ^1.7.4
+        version: 1.7.4
+      '@auth/express':
+        specifier: ^0.8.4
+        version: 0.8.4(express@4.21.2)
       '@trpc/server':
         specifier: ^10.45.2
         version: 10.45.2
@@ -98,6 +104,28 @@ importers:
         version: 5.7.3
 
 packages:
+
+  '@auth/core@0.37.4':
+    resolution: {integrity: sha512-HOXJwXWXQRhbBDHlMU0K/6FT1v+wjtzdKhsNg0ZN7/gne6XPsIrjZ4daMcFnbq0Z/vsAbYBinQhhua0d77v7qw==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^6.8.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
+  '@auth/drizzle-adapter@1.7.4':
+    resolution: {integrity: sha512-OPZQakWWm5Hbx6okVMbtgI08WBliz/dCbFUXiPg9TThpp3Wh7MME/ubg4fW1oOp8P0gul6MkFvMVO733sVtd2w==}
+
+  '@auth/express@0.8.4':
+    resolution: {integrity: sha512-6D38JtAI/ttGv8juc69r4Y7ozE2Un6Ayvu5+Sx2N41E+FPyISnWIvTrvO8MO7ltbHI8yErhQaE327jDsP9JglQ==}
+    peerDependencies:
+      express: ^4.18.2
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -741,6 +769,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1638,6 +1669,9 @@ packages:
     resolution: {integrity: sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==}
     engines: {node: '>= 0.6.0'}
 
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -1774,6 +1808,9 @@ packages:
         optional: true
       '@types/node':
         optional: true
+
+  oauth4webapi@3.3.0:
+    resolution: {integrity: sha512-ZlozhPlFfobzh3hB72gnBFLjXpugl/dljz1fJSRdqaV2r3D5dmi5lg2QWI0LmUYuazmE+b5exsloEv6toUtw9g==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -1965,6 +2002,14 @@ packages:
   postgres@3.4.5:
     resolution: {integrity: sha512-cDWgoah1Gez9rN3H4165peY9qfpEo+SA61oQv65O3cRUE1pOEoJWwddwcqKE8XZYjbblOJlYDlLV4h67HrEVDg==}
     engines: {node: '>=12'}
+
+  preact-render-to-string@6.5.11:
+    resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact@10.24.3:
+    resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2352,6 +2397,31 @@ packages:
 
 snapshots:
 
+  '@auth/core@0.37.4':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      jose: 5.10.0
+      oauth4webapi: 3.3.0
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
+
+  '@auth/drizzle-adapter@1.7.4':
+    dependencies:
+      '@auth/core': 0.37.4
+    transitivePeerDependencies:
+      - '@simplewebauthn/browser'
+      - '@simplewebauthn/server'
+      - nodemailer
+
+  '@auth/express@0.8.4(express@4.21.2)':
+    dependencies:
+      '@auth/core': 0.37.4
+      express: 4.21.2
+    transitivePeerDependencies:
+      - '@simplewebauthn/browser'
+      - '@simplewebauthn/server'
+      - nodemailer
+
   '@drizzle-team/brocli@0.10.2': {}
 
   '@esbuild-kit/core-utils@3.3.2':
@@ -2720,6 +2790,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.18.0
+
+  '@panva/hkdf@1.2.1': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -3683,6 +3755,8 @@ snapshots:
 
   jmespath@0.16.0: {}
 
+  jose@5.10.0: {}
+
   joycon@3.1.1: {}
 
   js-yaml@4.1.0:
@@ -3790,6 +3864,8 @@ snapshots:
     optionalDependencies:
       '@types/express': 5.0.0
       '@types/node': 22.10.7
+
+  oauth4webapi@3.3.0: {}
 
   object-assign@4.1.1: {}
 
@@ -3937,6 +4013,12 @@ snapshots:
   postgres-range@1.1.4: {}
 
   postgres@3.4.5: {}
+
+  preact-render-to-string@6.5.11(preact@10.24.3):
+    dependencies:
+      preact: 10.24.3
+
+  preact@10.24.3: {}
 
   prelude-ls@1.2.1: {}
 

--- a/src/backend/src/db/migrations/0003_whole_hellion.sql
+++ b/src/backend/src/db/migrations/0003_whole_hellion.sql
@@ -1,0 +1,62 @@
+CREATE TABLE "account" (
+	"userId" uuid NOT NULL,
+	"type" text NOT NULL,
+	"provider" text NOT NULL,
+	"providerAccountId" text NOT NULL,
+	"refresh_token" text,
+	"access_token" text,
+	"expires_at" integer,
+	"token_type" text,
+	"scope" text,
+	"id_token" text,
+	"session_state" text
+);
+--> statement-breakpoint
+CREATE TABLE "authenticator" (
+	"credentialID" text NOT NULL,
+	"userId" uuid NOT NULL,
+	"providerAccountId" text NOT NULL,
+	"credentialPublicKey" text NOT NULL,
+	"counter" integer NOT NULL,
+	"credentialDeviceType" text NOT NULL,
+	"credentialBackedUp" boolean NOT NULL,
+	"transports" text,
+	CONSTRAINT "authenticator_credentialID_unique" UNIQUE("credentialID")
+);
+--> statement-breakpoint
+CREATE TABLE "session" (
+	"sessionToken" text PRIMARY KEY NOT NULL,
+	"userId" uuid NOT NULL,
+	"expires" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "verificationToken" (
+	"identifier" text NOT NULL,
+	"token" text NOT NULL,
+	"expires" timestamp NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "users" RENAME TO "user";--> statement-breakpoint
+ALTER TABLE "user" RENAME COLUMN "username" TO "name";--> statement-breakpoint
+ALTER TABLE "user" RENAME COLUMN "created_at" TO "createdAt";--> statement-breakpoint
+ALTER TABLE "api_keys" DROP CONSTRAINT "api_keys_user_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "api_request_logs" DROP CONSTRAINT "api_request_logs_user_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "bots" DROP CONSTRAINT "bots_user_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "api_keys" ALTER COLUMN "user_id" SET DATA TYPE uuid;--> statement-breakpoint
+ALTER TABLE "api_request_logs" ALTER COLUMN "user_id" SET DATA TYPE uuid;--> statement-breakpoint
+ALTER TABLE "bots" ALTER COLUMN "user_id" SET DATA TYPE uuid;--> statement-breakpoint
+ALTER TABLE "user" ALTER COLUMN "id" SET DATA TYPE uuid;--> statement-breakpoint
+ALTER TABLE "user" ALTER COLUMN "email" SET DATA TYPE text;--> statement-breakpoint
+ALTER TABLE "user" ALTER COLUMN "email" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "emailVerified" timestamp;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "image" text;--> statement-breakpoint
+ALTER TABLE "account" ADD CONSTRAINT "account_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "authenticator" ADD CONSTRAINT "authenticator_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "session" ADD CONSTRAINT "session_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "api_request_logs" ADD CONSTRAINT "api_request_logs_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "bots" ADD CONSTRAINT "bots_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user" ADD CONSTRAINT "user_email_unique" UNIQUE("email");

--- a/src/backend/src/db/migrations/meta/0003_snapshot.json
+++ b/src/backend/src/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,704 @@
+{
+  "id": "966ad37d-f0ee-4669-952e-c21dd17078dc",
+  "prevId": "be5d7855-a258-4736-8f4e-893f24576a29",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_revoked": {
+          "name": "is_revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_user_id_fk": {
+          "name": "api_keys_user_id_user_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_request_logs": {
+      "name": "api_request_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_request_logs_api_key_id_api_keys_id_fk": {
+          "name": "api_request_logs_api_key_id_api_keys_id_fk",
+          "tableFrom": "api_request_logs",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "api_request_logs_user_id_user_id_fk": {
+          "name": "api_request_logs_user_id_user_id_fk",
+          "tableFrom": "api_request_logs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authenticator": {
+      "name": "authenticator",
+      "schema": "",
+      "columns": {
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialPublicKey": {
+          "name": "credentialPublicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialDeviceType": {
+          "name": "credentialDeviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialBackedUp": {
+          "name": "credentialBackedUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authenticator_userId_user_id_fk": {
+          "name": "authenticator_userId_user_id_fk",
+          "tableFrom": "authenticator",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authenticator_credentialID_unique": {
+          "name": "authenticator_credentialID_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credentialID"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bots": {
+      "name": "bots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bot_display_name": {
+          "name": "bot_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_image": {
+          "name": "bot_image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_name": {
+          "name": "meeting_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_info": {
+          "name": "meeting_info",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recording": {
+          "name": "recording",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat": {
+          "name": "last_heartbeat",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'READY_TO_DEPLOY'"
+        },
+        "deployment_error": {
+          "name": "deployment_error",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_interval": {
+          "name": "heartbeat_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automatic_leave": {
+          "name": "automatic_leave",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bots_user_id_user_id_fk": {
+          "name": "bots_user_id_user_id_fk",
+          "tableFrom": "bots",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_bot_id_bots_id_fk": {
+          "name": "events_bot_id_bots_id_fk",
+          "tableFrom": "events",
+          "tableTo": "bots",
+          "columnsFrom": [
+            "bot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationToken": {
+      "name": "verificationToken",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/backend/src/db/migrations/meta/_journal.json
+++ b/src/backend/src/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1739804379486,
       "tag": "0002_fast_phil_sheldon",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1740261786509,
+      "tag": "0003_whole_hellion",
+      "breakpoints": true
     }
   ]
 }

--- a/src/backend/src/db/schema.ts
+++ b/src/backend/src/db/schema.ts
@@ -7,26 +7,109 @@ import {
   integer,
   boolean,
   pgTableCreator,
+  text,
+  primaryKey,
+  uuid,
 } from 'drizzle-orm/pg-core'
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod'
-
+import { AdapterAccountType } from '@auth/core/adapters'
 const pgTable = pgTableCreator((name) => name)
 
-export const users = pgTable('users', {
-  id: serial('id').primaryKey(),
-  username: varchar('username', { length: 255 }).notNull(),
-  email: varchar('email', { length: 255 }).notNull(),
-  createdAt: timestamp('created_at').defaultNow(),
+/** AUTH TABLES */
+export const users = pgTable('user', {
+  id: uuid('id')
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  name: text('name'),
+  email: text('email').unique(),
+  emailVerified: timestamp('emailVerified', { mode: 'date' }),
+  image: text('image'),
+  createdAt: timestamp('createdAt').defaultNow(),
 })
+
 export const insertUserSchema = createInsertSchema(users).omit({
   id: true,
   createdAt: true,
 })
+
 export const selectUserSchema = createSelectSchema(users)
 
+export const accounts = pgTable(
+  'account',
+  {
+    userId: uuid('userId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    type: text('type').$type<AdapterAccountType>().notNull(),
+    provider: text('provider').notNull(),
+    providerAccountId: text('providerAccountId').notNull(),
+    refresh_token: text('refresh_token'),
+    access_token: text('access_token'),
+    expires_at: integer('expires_at'),
+    token_type: text('token_type'),
+    scope: text('scope'),
+    id_token: text('id_token'),
+    session_state: text('session_state'),
+  },
+  (account) => [
+    {
+      compoundKey: primaryKey({
+        columns: [account.provider, account.providerAccountId],
+      }),
+    },
+  ]
+)
+
+export const sessions = pgTable('session', {
+  sessionToken: text('sessionToken').primaryKey(),
+  userId: uuid('userId')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  expires: timestamp('expires', { mode: 'date' }).notNull(),
+})
+
+export const verificationTokens = pgTable(
+  'verificationToken',
+  {
+    identifier: text('identifier').notNull(),
+    token: text('token').notNull(),
+    expires: timestamp('expires', { mode: 'date' }).notNull(),
+  },
+  (verificationToken) => [
+    {
+      compositePk: primaryKey({
+        columns: [verificationToken.identifier, verificationToken.token],
+      }),
+    },
+  ]
+)
+
+export const authenticators = pgTable(
+  'authenticator',
+  {
+    credentialID: text('credentialID').notNull().unique(),
+    userId: uuid('userId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    providerAccountId: text('providerAccountId').notNull(),
+    credentialPublicKey: text('credentialPublicKey').notNull(),
+    counter: integer('counter').notNull(),
+    credentialDeviceType: text('credentialDeviceType').notNull(),
+    credentialBackedUp: boolean('credentialBackedUp').notNull(),
+    transports: text('transports'),
+  },
+  (authenticator) => [
+    {
+      compositePK: primaryKey({
+        columns: [authenticator.userId, authenticator.credentialID],
+      }),
+    },
+  ]
+)
+/** API KEYS */
 export const apiKeys = pgTable('api_keys', {
   id: serial('id').primaryKey(),
-  userId: integer('user_id')
+  userId: uuid('user_id')
     .references(() => users.id)
     .notNull(),
   key: varchar('key', { length: 64 }).notNull().unique(),
@@ -45,12 +128,13 @@ export const insertApiKeySchema = createInsertSchema(apiKeys).pick({
 
 export const selectApiKeySchema = createSelectSchema(apiKeys)
 
+/** API REQUEST LOGS */
 export const apiRequestLogs = pgTable('api_request_logs', {
   id: serial('id').primaryKey(),
   apiKeyId: integer('api_key_id')
     .references(() => apiKeys.id)
     .notNull(),
-  userId: integer('user_id')
+  userId: uuid('user_id')
     .references(() => users.id)
     .notNull(),
   method: varchar('method', { length: 10 }).notNull(),
@@ -72,6 +156,7 @@ export const insertApiRequestLogSchema = createInsertSchema(
 
 export const selectApiRequestLogSchema = createSelectSchema(apiRequestLogs)
 
+/** BOT CONFIG */
 const silenceDetectionSchema = z.object({
   timeout: z.number(), // the milliseconds of silence before the bot leaves
   activateAfter: z.number(), // the milliseconds the bot waits before it begins to detect silence
@@ -159,7 +244,7 @@ export const bots = pgTable('bots', {
   botDisplayName: varchar('bot_display_name', { length: 255 }).notNull(),
   botImage: varchar('bot_image', { length: 255 }),
   // refernce user
-  userId: integer('user_id')
+  userId: uuid('user_id')
     .references(() => users.id)
     .notNull(),
   // meeting stuff
@@ -186,7 +271,7 @@ export const bots = pgTable('bots', {
 export const insertBotSchema = z.object({
   botDisplayName: z.string().optional(),
   botImage: z.string().url().optional(),
-  userId: z.number(),
+  userId: z.string(),
   meetingTitle: z.string().optional(),
   meetingInfo: meetingInfoSchema,
   startTime: z.date().optional(),
@@ -201,7 +286,7 @@ export type SelectBotType = z.infer<typeof selectBotSchema>
 
 export const botConfigSchema = z.object({
   id: z.number(),
-  userId: z.number(),
+  userId: z.string(),
   meetingInfo: meetingInfoSchema,
   meetingTitle: z.string(),
   startTime: z.date(),

--- a/src/backend/src/routers/apiKeys.ts
+++ b/src/backend/src/routers/apiKeys.ts
@@ -204,4 +204,4 @@ export const apiKeysRouter = createTRPCRouter({
         total: count,
       }
     }),
-}) 
+})

--- a/src/backend/src/routers/bots.ts
+++ b/src/backend/src/routers/bots.ts
@@ -123,11 +123,8 @@ export const botsRouter = createTRPCRouter({
     .output(selectBotSchema)
     .mutation(async ({ input, ctx }) => {
       // Check if the bot belongs to the user
-      const bot = await ctx.db
-        .select()
-        .from(bots)
-        .where(eq(bots.id, input.id))
-      
+      const bot = await ctx.db.select().from(bots).where(eq(bots.id, input.id))
+
       if (!bot[0] || bot[0].userId !== ctx.auth.userId) {
         throw new Error('Bot not found')
       }
@@ -179,11 +176,8 @@ export const botsRouter = createTRPCRouter({
     .output(z.object({ message: z.string() }))
     .mutation(async ({ input, ctx }) => {
       // Check if the bot belongs to the user
-      const bot = await ctx.db
-        .select()
-        .from(bots)
-        .where(eq(bots.id, input.id))
-      
+      const bot = await ctx.db.select().from(bots).where(eq(bots.id, input.id))
+
       if (!bot[0] || bot[0].userId !== ctx.auth.userId) {
         throw new Error('Bot not found')
       }
@@ -286,11 +280,8 @@ export const botsRouter = createTRPCRouter({
     .output(selectBotSchema)
     .mutation(async ({ input, ctx }) => {
       // Check if the bot belongs to the user
-      const bot = await ctx.db
-        .select()
-        .from(bots)
-        .where(eq(bots.id, input.id))
-      
+      const bot = await ctx.db.select().from(bots).where(eq(bots.id, input.id))
+
       if (!bot[0] || bot[0].userId !== ctx.auth.userId) {
         throw new Error('Bot not found')
       }

--- a/src/backend/src/routers/events.ts
+++ b/src/backend/src/routers/events.ts
@@ -93,7 +93,11 @@ export const eventsRouter = createTRPCRouter({
         .leftJoin(bots, eq(events.botId, bots.id))
         .where(eq(events.id, input.id))
 
-      if (!result[0] || !result[0].bot || result[0].bot.userId !== ctx.auth.userId) {
+      if (
+        !result[0] ||
+        !result[0].bot ||
+        result[0].bot.userId !== ctx.auth.userId
+      ) {
         throw new Error('Event not found')
       }
       return result[0].event
@@ -143,7 +147,11 @@ export const eventsRouter = createTRPCRouter({
         .leftJoin(bots, eq(events.botId, bots.id))
         .where(eq(events.id, input.id))
 
-      if (!event[0] || !event[0].bot || event[0].bot.userId !== ctx.auth.userId) {
+      if (
+        !event[0] ||
+        !event[0].bot ||
+        event[0].bot.userId !== ctx.auth.userId
+      ) {
         throw new Error('Event not found')
       }
 
@@ -180,7 +188,11 @@ export const eventsRouter = createTRPCRouter({
         .leftJoin(bots, eq(events.botId, bots.id))
         .where(eq(events.id, input.id))
 
-      if (!event[0] || !event[0].bot || event[0].bot.userId !== ctx.auth.userId) {
+      if (
+        !event[0] ||
+        !event[0].bot ||
+        event[0].bot.userId !== ctx.auth.userId
+      ) {
         throw new Error('Event not found')
       }
 

--- a/src/backend/src/routers/users.ts
+++ b/src/backend/src/routers/users.ts
@@ -26,7 +26,7 @@ export const usersRouter = createTRPCRouter({
         description: 'Get a specific user by their ID',
       },
     })
-    .input(z.object({ id: z.number() }))
+    .input(z.object({ id: z.string() }))
     .output(selectUserSchema)
     .query(async ({ ctx, input }) => {
       const result = await ctx.db
@@ -67,7 +67,7 @@ export const usersRouter = createTRPCRouter({
     })
     .input(
       z.object({
-        id: z.number(),
+        id: z.string(),
         data: insertUserSchema.partial(),
       })
     )
@@ -93,7 +93,7 @@ export const usersRouter = createTRPCRouter({
         description: 'Delete a user by their ID',
       },
     })
-    .input(z.object({ id: z.number() }))
+    .input(z.object({ id: z.string() }))
     .output(selectUserSchema)
     .mutation(async ({ ctx, input }) => {
       const result = await ctx.db

--- a/src/backend/src/server/auth.ts
+++ b/src/backend/src/server/auth.ts
@@ -1,0 +1,30 @@
+import { DrizzleAdapter } from '@auth/drizzle-adapter'
+import { ExpressAuthConfig } from '@auth/express'
+import GitHub from '@auth/express/providers/github'
+import { db } from '../db'
+
+export const authConfig: ExpressAuthConfig = {
+  adapter: DrizzleAdapter(db),
+  providers: [GitHub],
+  session: {
+    strategy: 'database',
+  },
+  callbacks: {
+    async redirect() {
+      // always redirect to frontend url upon login
+      return `${process.env.FRONTEND_URL}`
+    },
+    async session({ session, user }) {
+      // Send properties to the client, using user instead of token since we're using database strategy
+      return {
+        ...session,
+        user: {
+          ...session.user,
+          id: user.id,
+        },
+      }
+    },
+  },
+  // Only enable debug in development
+  debug: process.env.NODE_ENV === 'development',
+}

--- a/src/backend/src/server/index.ts
+++ b/src/backend/src/server/index.ts
@@ -1,4 +1,4 @@
-import express from 'express'
+import express, { NextFunction, Request, Response } from 'express'
 import { createExpressMiddleware } from '@trpc/server/adapters/express'
 import { createOpenApiExpressMiddleware } from 'trpc-openapi'
 import swaggerUi from 'swagger-ui-express'
@@ -6,12 +6,31 @@ import cors from 'cors'
 import { createTRPCContext } from './trpc.js'
 import { openApiDocument } from './openapi.js'
 import { appRouter } from '../routers/index.js'
+import { ExpressAuth } from '@auth/express'
+import { authConfig } from './auth.js'
+import { getSession } from '@auth/express'
 
 const port = process.env.PORT || 3001
 
 const app = express()
 
-app.use(cors())
+app.use(
+  cors({
+    origin: process.env.FRONTEND_URL,
+    credentials: true,
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+  })
+)
+
+// This endpoint is used by the auth router
+app.set('trust proxy', true)
+app.use('/auth/*', ExpressAuth(authConfig))
+// add the session to the request object
+app.use(async (req: Request, res: Response, next: NextFunction) => {
+  res.locals.session = await getSession(req, authConfig)
+  next()
+})
 
 // This endpoint is used by tRPC clients for type-safe API calls
 app.use(

--- a/src/bots/src/types.ts
+++ b/src/bots/src/types.ts
@@ -31,7 +31,7 @@ export type AutomaticLeave = {
 
 export type BotConfig = {
   id: number;
-  userId: number;
+  userId: string;
   meetingInfo: MeetingInfo;
   meetingTitle: string;
   startTime: Date;

--- a/src/frontend/.env.example
+++ b/src/frontend/.env.example
@@ -10,4 +10,4 @@
 # should be updated accordingly.
 
 DATABASE_URL=""
-BACKEND_URL="http://127.0.0.1:3001/api/trpc"
+NEXT_PUBLIC_BACKEND_URL="http://127.0.0.1:3001/api/trpc"

--- a/src/frontend/next.config.js
+++ b/src/frontend/next.config.js
@@ -5,6 +5,16 @@
 import "./src/env.js";
 
 /** @type {import("next").NextConfig} */
-const config = {};
+const config = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+        pathname: "/**",
+      },
+    ],
+  },
+};
 
 export default config;

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@auth/core": "^0.37.4",
     "@auth/drizzle-adapter": "^1.7.2",
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.5",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@auth/core':
+        specifier: ^0.37.4
+        version: 0.37.4
       '@auth/drizzle-adapter':
         specifier: ^1.7.2
         version: 1.7.4

--- a/src/frontend/src/app/page.tsx
+++ b/src/frontend/src/app/page.tsx
@@ -1,7 +1,67 @@
-export default async function Home() {
+"use client";
+
+import { SignInButton } from "@/components/auth/SignInButton";
+import { SignOutButton } from "@/components/auth/SignOutButton";
+import { type Session } from "@auth/core/types";
+import Image from "next/image";
+import { useEffect, useState } from "react";
+
+async function getSession(): Promise<Session | null> {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_BACKEND_URL}/auth/session`,
+    {
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+
+  if (!response.ok) {
+    return null;
+  }
+
+  return response.json() as Promise<Session>;
+}
+
+export default function Home() {
+  const [session, setSession] = useState<Session | null>(null);
+
+  useEffect(() => {
+    void getSession().then(setSession);
+  }, []);
+
   return (
-    <main>
-      <h1>Content</h1>
+    <main className="flex min-h-screen flex-col items-center justify-center p-24">
+      <div className="z-10 w-full max-w-5xl items-center justify-between font-mono text-sm">
+        Session: {String(session)}
+        {session?.user ? (
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex items-center gap-4">
+              {session.user.image && (
+                <Image
+                  src={session.user.image}
+                  alt={session.user.name ?? "User avatar"}
+                  className="h-12 w-12 rounded-full"
+                  width={48}
+                  height={48}
+                />
+              )}
+              <div>
+                <p className="text-xl font-bold">{session.user.name}</p>
+                <p className="text-gray-500">{session.user.email}</p>
+              </div>
+            </div>
+            <SignOutButton />
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-4">
+            <h1 className="text-2xl font-bold">Welcome to MeetingBot</h1>
+            <p className="text-gray-500">Please sign in to continue</p>
+            <SignInButton />
+          </div>
+        )}
+      </div>
     </main>
   );
 }

--- a/src/frontend/src/components/auth/SignInButton.tsx
+++ b/src/frontend/src/components/auth/SignInButton.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export function SignInButton() {
+  const router = useRouter();
+
+  const handleSignIn = async () => {
+    // Redirect to GitHub OAuth using standard Auth.js endpoint
+    router.push(
+      `${process.env.NEXT_PUBLIC_BACKEND_URL}/auth/signin?provider=github`,
+    );
+  };
+
+  return (
+    <button
+      onClick={handleSignIn}
+      className="rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700"
+    >
+      Sign in with GitHub
+    </button>
+  );
+}

--- a/src/frontend/src/components/auth/SignOutButton.tsx
+++ b/src/frontend/src/components/auth/SignOutButton.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export function SignOutButton() {
+  const router = useRouter();
+
+  const handleSignOut = async () => {
+    // Redirect to GitHub OAuth using standard Auth.js endpoint
+    router.push(`${process.env.NEXT_PUBLIC_BACKEND_URL}/auth/signout`);
+  };
+
+  return (
+    <button
+      onClick={handleSignOut}
+      className="rounded bg-red-500 px-4 py-2 font-bold text-white hover:bg-red-700"
+    >
+      Sign Out
+    </button>
+  );
+}

--- a/src/frontend/src/env.js
+++ b/src/frontend/src/env.js
@@ -11,7 +11,6 @@ export const env = createEnv({
       .enum(["development", "test", "production"])
       .default("development"),
     DATABASE_URL: z.string().url(),
-    BACKEND_URL: z.string().url(),
   },
 
   /**
@@ -21,6 +20,7 @@ export const env = createEnv({
    */
   client: {
     // NEXT_PUBLIC_CLIENTVAR: z.string(),
+    NEXT_PUBLIC_BACKEND_URL: z.string().url(),
   },
 
   /**
@@ -30,7 +30,7 @@ export const env = createEnv({
   runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
     DATABASE_URL: process.env.DATABASE_URL,
-    BACKEND_URL: process.env.BACKEND_URL,
+    NEXT_PUBLIC_BACKEND_URL: process.env.NEXT_PUBLIC_BACKEND_URL,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/src/frontend/src/trpc/trpc-react.tsx
+++ b/src/frontend/src/trpc/trpc-react.tsx
@@ -10,6 +10,7 @@ import { useState } from "react";
 import { makeQueryClient } from "./query-client";
 import { type AppRouter } from "../../../backend/src/routers";
 import superjson from "superjson";
+import { env } from "~/env";
 
 export const trpcReact = createTRPCReact<AppRouter>();
 let clientQueryClientSingleton: QueryClient;
@@ -36,7 +37,13 @@ export function TRPCProvider(
       transformer: superjson,
       links: [
         httpBatchLink({
-          url: process.env.BACKEND_URL ?? "http://127.0.0.1:3001/api/trpc",
+          url: `${env.NEXT_PUBLIC_BACKEND_URL}/api/trpc`,
+          fetch(url, options) {
+            return fetch(url, {
+              ...options,
+              credentials: "include",
+            });
+          },
         }),
       ],
     }),

--- a/src/frontend/src/trpc/trpc-vanilla.tsx
+++ b/src/frontend/src/trpc/trpc-vanilla.tsx
@@ -1,18 +1,19 @@
 import { createTRPCProxyClient, httpBatchLink } from "@trpc/client";
 import { type AppRouter } from "../../../backend/src/routers";
 import superjson from "superjson";
+import { env } from "~/env";
 
 export const trpcVanilla = createTRPCProxyClient<AppRouter>({
   transformer: superjson,
   links: [
     httpBatchLink({
-      url: process.env.BACKEND_URL ?? "http://127.0.0.1:3001/api/trpc",
-      // You can pass any HTTP headers you wish here
-      // async headers() {
-      //   return {
-      //     authorization: getAuthCookie(),
-      //   };
-      // },
+      url: `${env.NEXT_PUBLIC_BACKEND_URL}/api/trpc`,
+      fetch(url, options) {
+        return fetch(url, {
+          ...options,
+          credentials: "include",
+        });
+      },
     }),
   ],
 });


### PR DESCRIPTION
Hooked-up express auth to the backend to allow users to access backend endpoints via sessions *alongside* API key access. 

## Relevant Documentation
- I installed it according to [Installation Docs](https://authjs.dev/reference/express)
- I set up the env variables according to [Deployment Docs](https://authjs.dev/getting-started/deployment), [Env Variable Docs](https://authjs.dev/guides/environment-variables?framework=express)
- Took the database schema from [Drizzle Schema Docs](https://authjs.dev/getting-started/adapters/drizzle?framework=next-js#schemas)
- Set-up the front-end according to [Sign-in/Sign-out](https://authjs.dev/getting-started/session-management/login?framework=express), [Get Session](https://authjs.dev/getting-started/session-management/get-session?framework=express) which uses [Built-in Pages](https://authjs.dev/guides/pages/built-in-pages)
- TRPC Middleware based off of [Protecting Resources Docs](https://authjs.dev/getting-started/session-management/protecting?framework=express)
- Set-up github provider according to [GitHub Provider Docs](https://next-auth.js.org/providers/github) and [OAuth with Github Guide](https://authjs.dev/guides/configuring-github?framework=next-js)


## Flow
- User clicks sign-up and is redirected to a page hosted on the backend
- Sign up flow is entirely handled on the backend `/auth/...` endpoints
 - User is redirected to front-end now in a valid session
- When client accesses a protected procedure, the request will be validated by `authMiddlewear`


complete MEE-168