### PR TITLE
feat: seperated dashboard and welcome dashboard

### DIFF
--- a/src/frontend/src/app/components/Dashboard.tsx
+++ b/src/frontend/src/app/components/Dashboard.tsx
@@ -1,0 +1,3 @@
+export default function Dashboard() {
+  return <div>Dashboard</div>;
+}

--- a/src/frontend/src/app/components/ErrorAlert.tsx
+++ b/src/frontend/src/app/components/ErrorAlert.tsx
@@ -1,0 +1,16 @@
+import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
+import { Terminal } from "lucide-react";
+
+interface ErrorAlertProps {
+  errorMessage: string;
+}
+
+export default function ErrorAlert({ errorMessage }: ErrorAlertProps) {
+  return (
+    <Alert className="max-w-screen-sm">
+      <Terminal className="h-4 w-4" />
+      <AlertTitle>An error occurred</AlertTitle>
+      <AlertDescription>{errorMessage}</AlertDescription>
+    </Alert>
+  );
+}

--- a/src/frontend/src/app/page.tsx
+++ b/src/frontend/src/app/page.tsx
@@ -1,10 +1,65 @@
 "use client";
+import { Skeleton } from "~/components/ui/skeleton";
 import WelcomeDashboard from "./components/WelcomeDashboard";
+import { trpcReact } from "~/trpc/trpc-react";
+import ErrorAlert from "./components/ErrorAlert";
+import Dashboard from "./components/Dashboard";
+import { useSession } from "~/contexts/SessionContext";
 
 export default function Home() {
+  const {
+    session,
+    isLoading: isSessionLoading,
+    error: sessionError,
+  } = useSession();
+  const { data, isLoading, error } = trpcReact.apiKeys.getApiKeyCount.useQuery(
+    {},
+    {
+      enabled: !!session?.user?.id,
+    },
+  );
+
   return (
     <main>
-      <WelcomeDashboard />
+      {isSessionLoading || (!!session?.user?.id && isLoading) ? ( // if loading, show skeleton
+        <div>
+          <div className="mb-5 mt-5">
+            <Skeleton className="h-10 w-72" />
+            <Skeleton className="mt-2 h-5 w-96" />
+          </div>
+          <div>
+            <div className="grid h-full gap-6 lg:grid-cols-3">
+              <div className="grid h-full gap-6 md:col-span-2 md:grid-cols-2">
+                <div className="md:col-span-2">
+                  <Skeleton className="h-40 w-full" />
+                </div>
+                <div>
+                  <Skeleton className="h-48 w-full" />
+                </div>
+                <div>
+                  <Skeleton className="h-48 w-full" />
+                </div>
+              </div>
+              <div className="col-span-full h-full md:col-span-1 md:row-span-2">
+                <Skeleton className="h-full w-full" />
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : error || sessionError ? ( // if error, show error alert
+        <ErrorAlert
+          errorMessage={
+            error?.message ??
+            sessionError?.message ??
+            "An unknown error occurred"
+          }
+        />
+      ) : !session?.user?.id || data?.count === 0 ? ( // if user is not logged in or has no api keys, show welcome dashboard
+        <WelcomeDashboard />
+      ) : (
+        // if user has api keys, show dashboard
+        <Dashboard />
+      )}
     </main>
   );
 }

--- a/src/frontend/src/components/ui/alert.tsx
+++ b/src/frontend/src/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "~/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertTitle, AlertDescription }

--- a/src/frontend/src/components/ui/skeleton.tsx
+++ b/src/frontend/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "~/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-primary/10", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/frontend/src/styles/globals.css
+++ b/src/frontend/src/styles/globals.css
@@ -64,3 +64,12 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/src/frontend/src/trpc/query-client.ts
+++ b/src/frontend/src/trpc/query-client.ts
@@ -5,7 +5,9 @@ export function makeQueryClient() {
   return new QueryClient({
     defaultOptions: {
       queries: {
-        staleTime: 30 * 1000,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+        refetchOnMount: false,
       },
     },
   });


### PR DESCRIPTION
towards MEE-169

### TL;DR
Show the correct dashboard based on the user's session and whether or not they have yet to create an API key handling loading states, error handling, and conditional rendering appropriately.

### What changed?
- Updated page.tsx to conditionally render different views based on:
  - Loading state
  - Error state
  - User session status
  - API key count
- Created new `Dashboard` (for the returning user)
- Created `ErrorAlert` component (using the newly added `Alert`) to use when API fetches fail
- Added `Skeleton` component to use in loading states

- Modified query client configuration to reduce unnecessary refetching
- Added base styling rules for borders and outlines

### How to test?
1. Test session loading state and error states by turning off wifi or stopping the backend-server
2. Test API key count error handling by making the endpoint throw an error
3. Check dashboard rendering:
   - When logged out (should show WelcomeDashboard)
   - When logged in with no API keys (should show WelcomeDashboard)
   - When logged in with API keys (should show Dashboard)
