### PR TITLE
fix: use zod refine instead of discriminatedUnion to be compatible with OpenAPI

### DIFF
--- a/src/backend/src/routers/bots.ts
+++ b/src/backend/src/routers/bots.ts
@@ -151,14 +151,21 @@ export const botsRouter = createTRPCRouter({
       },
     })
     .input(
-      z.discriminatedUnion('status', [
         z.object({
           id: z.number(),
-          status: z.literal('DONE'),
-          recording: z.string(), // the object id of the recording
-        }),
-        z.object({ id: z.number(), status: status.exclude(['DONE']) }),
-      ])
+        status: status,
+        recording: z.string().optional(),
+      }).refine(
+        (data) => {
+          if (data.status === 'DONE') {
+            return data.recording !== undefined
+          }
+          return true
+        },
+        {
+          message: 'Recording is required when status is DONE',
+        }
+      )
     )
     .output(selectBotSchema)
     .mutation(async ({ input, ctx }) => {


### PR DESCRIPTION
Replaced the discriminated union approach for validating bot status updates with a single object schema that uses `refine()`. The new implementation ensures that when a bot's status is set to 'DONE', a recording ID must be provided, while making the recording field optional for other statuses.

Using discriminatedUnion gave an error because it's not compatible with the automatic OpenAPI docs generator.