### PR TITLE
feat: include recording in DONE event

### DIFF
--- a/src/bots/src/index.ts
+++ b/src/bots/src/index.ts
@@ -28,6 +28,9 @@ const main = async () => {
   console.log("Received bot data:", botData);
   const botId = botData.id;
 
+  // Declare key variable at the top level of the function
+  let key: string = "";
+
   // Initialize S3 client
   let s3Client: S3Client;
   if (process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY) {
@@ -117,10 +120,10 @@ const main = async () => {
       }
     }
 
-    // Create UUid
+    // Create UUID and initialize key
     const uuid = crypto.randomUUID();
     const contentType = bot.getContentType();
-    const key = `recordings/${uuid}-${
+    key = `recordings/${uuid}-${
       bot.settings.meetingInfo.platform
     }-recording.${contentType.split("/")[1]}`;
 
@@ -153,6 +156,6 @@ const main = async () => {
   console.log("Bot execution completed, heartbeat stopped.");
 
   // Report final DONE event
-  await reportEvent(botId, EventCode.DONE);
+  await reportEvent(botId, EventCode.DONE, { recording: key });
 };
 main();

--- a/src/bots/src/monitoring.ts
+++ b/src/bots/src/monitoring.ts
@@ -1,4 +1,4 @@
-import { type EventCode, Status } from "./types";
+import { EventCode, Status } from "./types";
 import { trpc } from "./trpc";
 import { setTimeout } from "timers/promises";
 
@@ -42,10 +42,19 @@ export const reportEvent = async (
 
     // Update bot status if this event type is a valid status
     if (eventType in Status) {
-      await trpc.bots.updateBotStatus.mutate({
-        id: botId,
-        status: eventType as unknown as Status,
-      });
+      // If the event is DONE, we need to include the recording parameter
+      if (eventType === EventCode.DONE && eventData?.recording) {
+        await trpc.bots.updateBotStatus.mutate({
+          id: botId,
+          status: eventType as unknown as Status,
+          recording: eventData.recording,
+        });
+      } else {
+        await trpc.bots.updateBotStatus.mutate({
+          id: botId,
+          status: eventType as unknown as Status,
+        });
+      }
     }
 
     console.log(`[${new Date().toISOString()}] Event reported: ${eventType}`);


### PR DESCRIPTION
### TL;DR

Added recording file path to the DONE event when a bot completes execution.

### What changed?

- Moved the `key` variable declaration to the top level of the main function to make it accessible throughout the function scope
- Modified the `reportEvent` function to include the recording file path when reporting the DONE event
- Updated the `updateBotStatus` mutation to conditionally include the recording parameter when the event is DONE