### PR TITLE
fix: remove /api prefix from backend URLs causing critical errors

### DIFF
--- a/src/frontend/src/app/components/SessionButton.tsx
+++ b/src/frontend/src/app/components/SessionButton.tsx
@@ -25,7 +25,7 @@ export default function SessionButton() {
   if (!session?.user) {
     return (
       <Link
-        href={`${env.NEXT_PUBLIC_BACKEND_URL}/api/auth/signin?provider=github`}
+        href={`${env.NEXT_PUBLIC_BACKEND_URL}/auth/signin?provider=github`}
       >
         <Button variant="outline" className="gap-2">
           Sign In
@@ -52,7 +52,7 @@ export default function SessionButton() {
         <DropdownMenuSeparator />
         <DropdownMenuItem>Profile</DropdownMenuItem>
         <Link
-          href={`${env.NEXT_PUBLIC_BACKEND_URL}/api/auth/signout`}
+          href={`${env.NEXT_PUBLIC_BACKEND_URL}/auth/signout`}
           className="cursor-pointer"
         >
           <DropdownMenuItem>Logout</DropdownMenuItem>

--- a/src/frontend/src/app/components/WelcomeDashboard.tsx
+++ b/src/frontend/src/app/components/WelcomeDashboard.tsx
@@ -39,7 +39,7 @@ export default function WelcomeDashboard() {
                     </Link>
                   ) : (
                     <Link
-                      href={`${env.NEXT_PUBLIC_BACKEND_URL}/api/auth/signin?provider=github`}
+                      href={`${env.NEXT_PUBLIC_BACKEND_URL}/auth/signin?provider=github`}
                     >
                       <Button>
                         Sign In <LogIn />

--- a/src/frontend/src/contexts/SessionContext.tsx
+++ b/src/frontend/src/contexts/SessionContext.tsx
@@ -26,7 +26,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   async function getSession(): Promise<Session | null> {
     try {
       const response = await fetch(
-        `${env.NEXT_PUBLIC_BACKEND_URL}/api/auth/session`,
+        `${env.NEXT_PUBLIC_BACKEND_URL}/auth/session`,
         {
           credentials: "include",
           headers: {

--- a/src/frontend/src/trpc/trpc-react.tsx
+++ b/src/frontend/src/trpc/trpc-react.tsx
@@ -37,7 +37,7 @@ export function TRPCProvider(
       transformer: superjson,
       links: [
         httpBatchLink({
-          url: `${env.NEXT_PUBLIC_BACKEND_URL}/api/trpc`,
+          url: `${env.NEXT_PUBLIC_BACKEND_URL}/trpc`,
           fetch(url, options) {
             return fetch(url, {
               ...options,

--- a/src/frontend/src/trpc/trpc-vanilla.tsx
+++ b/src/frontend/src/trpc/trpc-vanilla.tsx
@@ -7,7 +7,7 @@ export const trpcVanilla = createTRPCProxyClient<AppRouter>({
   transformer: superjson,
   links: [
     httpBatchLink({
-      url: `${env.NEXT_PUBLIC_BACKEND_URL}/api/trpc`,
+      url: `${env.NEXT_PUBLIC_BACKEND_URL}/trpc`,
       fetch(url, options) {
         return fetch(url, {
           ...options,


### PR DESCRIPTION
### TL;DR

Updated API endpoint paths by removing the `/api` prefix from authentication and tRPC routes.

### What changed?

Modified all frontend API endpoint references to remove the `/api` prefix:
- Updated authentication endpoints from `/api/auth/signin`, `/api/auth/signout`, and `/api/auth/session` to `/auth/signin`, `/auth/signout`, and `/auth/session` respectively
- Changed tRPC endpoint from `/api/trpc` to `/trpc`