### PR TITLE
feat: usage metric api

### DIFF
--- a/src/backend/request_testing.http
+++ b/src/backend/request_testing.http
@@ -81,7 +81,7 @@ GET http://127.0.0.1:3001/api/bots/53
 content-type: application/json
 x-api-key: 0bc3598273e72800afa66146686c2c5d28cff0aa76f9381b3fd59651e63b4000
 
-###
+###me
 
 # Get bot 53 recording
 GET http://127.0.0.1:3001/api/bots/53/recording
@@ -89,3 +89,10 @@ content-type: application/json
 x-api-key: 0bc3598273e72800afa66146686c2c5d28cff0aa76f9381b3fd59651e63b4000
 
 
+
+###
+
+# Check Bot Usage
+GET http://127.0.0.1:3001/api/usage/day
+content-type: application/json
+x-api-key: 0bc3598273e72800afa66146686c2c5d28cff0aa76f9381b3fd59651e63b4000

--- a/src/backend/src/db/schema.ts
+++ b/src/backend/src/db/schema.ts
@@ -13,6 +13,7 @@ import {
 } from 'drizzle-orm/pg-core'
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod'
 import { AdapterAccountType } from '@auth/core/adapters'
+import { usageRouter } from '../routers/usage'
 const pgTable = pgTableCreator((name) => name)
 
 /** AUTH TABLES */
@@ -335,4 +336,10 @@ export const insertEventSchema = createInsertSchema(events)
 export const selectEventSchema = createSelectSchema(events).extend({
   data: eventData.nullable(),
   eventType: eventCode,
+})
+
+export const dailyUsageSchema = z.object({
+  date: z.string().nullable(),
+  msEllapsed: z.number().nullable(),
+  count: z.number().nullable(),
 })

--- a/src/backend/src/routers/index.ts
+++ b/src/backend/src/routers/index.ts
@@ -2,11 +2,13 @@ import { createTRPCRouter } from '../server/trpc.js'
 import { botsRouter } from './bots'
 import { eventsRouter } from './events'
 import { apiKeysRouter } from './apiKeys'
+import { usageRouter } from './usage'
 
 export const appRouter = createTRPCRouter({
   bots: botsRouter,
   events: eventsRouter,
   apiKeys: apiKeysRouter,
+  usage: usageRouter,
 })
 
 export type AppRouter = typeof appRouter

--- a/src/backend/src/routers/usage.ts
+++ b/src/backend/src/routers/usage.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod'
+import { createTRPCRouter, protectedProcedure } from '../server/trpc'
+import {
+    events,
+    insertEventSchema,
+    selectEventSchema,
+    EVENT_DESCRIPTIONS,
+    bots,
+    dailyUsageSchema,
+} from '../db/schema'
+import { eq, not, and, isNull, isNotNull } from 'drizzle-orm'
+
+export const usageRouter = createTRPCRouter({
+
+    //TOOD: Split this into Monthly, Yearly etc.
+    getDayUsage: protectedProcedure
+        .meta({
+            openapi: {
+                method: 'GET',
+                path: '/usage/day',
+                description: 'Retrive a list of daily bot usage over the last week.\n'
+            },
+        })
+        .input(z.object({}))
+        .output(z.array(dailyUsageSchema))
+        .query(async ({ ctx }) => {
+
+            // Get all bots timestamp
+            const userBots = await ctx.db
+                .select({ startTime: bots.startTime, endTime: bots.lastHeartbeat, id: bots.id }) //TODO: End Time reflects this
+                .from(bots)
+                .where(and(eq(bots.userId, ctx.auth.userId), isNotNull(bots.lastHeartbeat)))
+
+            // Collect the Bot Id's.
+            const botIds = userBots.map((bot) => bot.id)
+            if (botIds.length === 0) {
+                return []
+            }
+
+            // Ensure botId is defined before using it in the query
+            const botId = botIds[0]
+            if (botId === undefined) {
+                throw new Error('Bot not found')
+            }
+
+            // Create a list of days
+
+            const eventsByDate: { [date: string]: any } = {}
+
+            userBots.forEach((bot) => {
+
+                if (bot.endTime === null) {
+                    return; //next in loop
+                }
+
+                // Get the start date
+                const startDate = bot.startTime.toISOString().split('T')[0]
+                if (!eventsByDate[startDate]) {
+                    eventsByDate[startDate] = {
+                        date: startDate,
+                        count: 0,
+                        msEllapsed: 0,
+                    }
+                }
+
+                //Time the bot ellapsed
+                const botElapsed = new Date(bot.endTime.toISOString()).getTime() - new Date(bot.startTime.toISOString()).getTime()
+                eventsByDate[startDate].msEllapsed += botElapsed
+                eventsByDate[startDate].count += 1
+            });
+
+            const outputObject = Object.values(eventsByDate);
+
+            // Passback List of values
+            console.log(outputObject);
+            return outputObject;
+        })
+});


### PR DESCRIPTION
### TL;DR

Added a new usage tracking feature to monitor daily bot activity.

### What changed?

- Created a new `usageRouter` with a `getDayUsage` endpoint to track daily bot usage
- Added a new `dailyUsageSchema` to the database schema
- Integrated the usage router into the main app router
- Added a test endpoint in the request testing file to check bot usage

### How to test?

1. Start the backend server
2. Use the new endpoint to check daily bot usage:
   ```
   GET http://127.0.0.1:3001/api/usage/day
   content-type: application/json
   x-api-key: 0bc3598273e72800afa66146686c2c5d28cff0aa76f9381b3fd59651e63b4000
   ```
3. Verify that the response contains daily usage data with date, msEllapsed, and count fields

### Why make this change?

This change enables tracking and analysis of bot usage patterns over time, providing valuable insights into how frequently bots are being used and for how long. This data can help with resource planning and understanding user engagement.