### PR TITLE
feat: frontend-usage-page

### DIFF
--- a/src/backend/src/db/schema.ts
+++ b/src/backend/src/db/schema.ts
@@ -339,7 +339,8 @@ export const selectEventSchema = createSelectSchema(events).extend({
 })
 
 export const dailyUsageSchema = z.object({
-  date: z.string().nullable(),
-  msEllapsed: z.number().nullable(),
-  count: z.number().nullable(),
+  date: z.string(),
+  msEllapsed: z.number(),
+  estimatedCost: z.string(),
+  count: z.number(),
 })

--- a/src/backend/src/routers/usage.ts
+++ b/src/backend/src/routers/usage.ts
@@ -8,17 +8,36 @@ import {
     bots,
     dailyUsageSchema,
 } from '../db/schema'
-import { eq, not, and, isNull, isNotNull } from 'drizzle-orm'
+import { eq, not, and, isNull, isNotNull, lt, gte } from 'drizzle-orm'
+
+
+const formatDayUsageDictToOutput = (eventsByDate: { [date: string]: any }) => {
+
+    // Create Output Object (list of dates)
+    let outputObject = Object.values(eventsByDate);
+
+    // Round & Stringify the Estimated Cost
+    outputObject = outputObject.map((d) => {
+        return {
+            ...d,
+            estimatedCost: d.estimatedCost.toFixed(2)
+        };
+    });
+
+    // Sort output keys (date)
+    return outputObject.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+}
+
 
 export const usageRouter = createTRPCRouter({
 
-    //TOOD: Split this into Monthly, Yearly etc.
-    getDayUsage: protectedProcedure
+
+    getAllUsage: protectedProcedure
         .meta({
             openapi: {
                 method: 'GET',
-                path: '/usage/day',
-                description: 'Retrive a list of daily bot usage over the last week.\n'
+                path: '/usage',
+                description: 'Retreive a sorted list of daily bot usage over all time\n'
             },
         })
         .input(z.object({}))
@@ -69,10 +88,161 @@ export const usageRouter = createTRPCRouter({
                 eventsByDate[startDate].count += 1
             });
 
-            const outputObject = Object.values(eventsByDate);
+            // Create Output Object (list of dates)
+            let outputObject = Object.values(eventsByDate);
+
+            // Alter to include a cost variable
+            outputObject = outputObject.map((d) => {
+                return {
+                    ...d,
+                    estimatedCost: (d.msEllapsed / 36000000).toFixed(2)
+                };
+            });
+
+            // Sort by keys
+            outputObject = outputObject.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 
             // Passback List of values
             console.log(outputObject);
             return outputObject;
+        }),
+
+    getWeekDailyUsage: protectedProcedure
+        .meta({
+            openapi: {
+                method: 'GET',
+                path: '/usage/week',
+                description: 'Retreive a list of daily bot usage over the last week. Empty days will be reported as well.\n'
+            },
+        })
+        .input(z.object({}))
+        .output(z.array(dailyUsageSchema))
+        .query(async ({ ctx }) => {
+
+            // Calculate start of this week
+            const today = new Date()
+            const startOfWeek = new Date(today.setDate(today.getDate() - today.getDay()))
+
+            // Get all bots timestamp
+            const userBots = await ctx.db
+                .select({ startTime: bots.startTime, endTime: bots.lastHeartbeat, id: bots.id }) //TODO: End Time reflects this
+                .from(bots)
+                .where(and(
+                    eq(bots.userId, ctx.auth.userId),
+                    gte(bots.startTime, startOfWeek), // After the beginning of the week
+                    isNotNull(bots.lastHeartbeat)))
+
+            // Empty -- No Data
+            if (userBots.length === 0) {
+                return []
+            }
+
+            // Populate entries for each day of the week
+            const eventsByDate: { [date: string]: any } = {}
+            for (let i = 0; i < 7; i++) {
+                const currentDate = new Date(startOfWeek);
+                currentDate.setDate(startOfWeek.getDate() + i);
+                const dateString = currentDate.toISOString().split('T')[0];
+
+                if (!eventsByDate[dateString]) {
+                    eventsByDate[dateString] = {
+                        date: dateString,
+                        count: 0,
+                        msEllapsed: 0,
+                        estimatedCost: 0,
+                    };
+                }
+            }
+
+            userBots.forEach((bot) => {
+
+                // Did not finish
+                if (bot.endTime === null) {
+                    return; //next in loop
+                }
+
+                // Get the start date
+                const startDate = bot.startTime.toISOString().split('T')[0]
+
+                //Time the bot ellapsed
+                const botElapsed = new Date(bot.endTime.toISOString()).getTime() - new Date(bot.startTime.toISOString()).getTime()
+                eventsByDate[startDate].msEllapsed += botElapsed
+                eventsByDate[startDate].count += 1
+                eventsByDate[startDate].estimatedCost += botElapsed / 36000000
+            });
+
+            // Return proper format
+            return formatDayUsageDictToOutput(eventsByDate);
+        }),
+
+
+    getMonthDailyUsage: protectedProcedure
+        .meta({
+            openapi: {
+                method: 'GET',
+                path: '/usage/month',
+                description: 'Retreive a list of daily bot usage over the last month. Empty days will be reported as well.\n'
+            },
+        })
+        .input(z.object({}))
+        .output(z.array(dailyUsageSchema))
+        .query(async ({ ctx }) => {
+
+            // Calculate start of this week
+            const today = new Date()
+            const startOfMonth = new Date(today.getFullYear(), today.getMonth(), 1)
+            const endOfMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0)
+            const daysInMonth = endOfMonth.getDate()
+
+            // Get all bots timestamp
+            const userBots = await ctx.db
+                .select({ startTime: bots.startTime, endTime: bots.lastHeartbeat, id: bots.id }) //TODO: End Time reflects this
+                .from(bots)
+                .where(and(
+                    eq(bots.userId, ctx.auth.userId),
+                    gte(bots.startTime, startOfMonth), // After the beginning of the week
+                    isNotNull(bots.lastHeartbeat)))
+
+            // Empty -- No Data
+            if (userBots.length === 0) {
+                return []
+            }
+
+            // Populate entries for each day of the week
+            const eventsByDate: { [date: string]: any } = {}
+
+            for (let i = 0; i <= daysInMonth; i++) {
+                const currentDate = new Date(startOfMonth);
+                currentDate.setDate(startOfMonth.getDate() + i);
+                const dateString = currentDate.toISOString().split('T')[0];
+
+                if (!eventsByDate[dateString]) {
+                    eventsByDate[dateString] = {
+                        date: dateString,
+                        count: 0,
+                        msEllapsed: 0,
+                        estimatedCost: 0,
+                    };
+                }
+            }
+
+            userBots.forEach((bot) => {
+
+                // Did not finish
+                if (bot.endTime === null) {
+                    return; //next in loop
+                }
+
+                // Get the start date
+                const startDate = bot.startTime.toISOString().split('T')[0]
+
+                //Time the bot ellapsed
+                const botElapsed = new Date(bot.endTime.toISOString()).getTime() - new Date(bot.startTime.toISOString()).getTime()
+                eventsByDate[startDate].msEllapsed += botElapsed
+                eventsByDate[startDate].count += 1
+                eventsByDate[startDate].estimatedCost += botElapsed / 36000000
+            });
+
+            return formatDayUsageDictToOutput(eventsByDate);
         })
 });

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -44,6 +44,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
+    "recharts": "^2.15.1",
     "server-only": "^0.0.1",
     "sonner": "^2.0.1",
     "superjson": "^2.2.2",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       react-hook-form:
         specifier: ^7.54.2
         version: 7.54.2(react@18.3.1)
+      recharts:
+        specifier: ^2.15.1
+        version: 2.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -173,6 +176,10 @@ packages:
         optional: true
       nodemailer:
         optional: true
+
+  '@babel/runtime@7.26.10':
+    resolution: {integrity: sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==}
+    engines: {node: '>=6.9.0'}
 
   '@emnapi/runtime@1.3.1':
     resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
@@ -975,6 +982,33 @@ packages:
   '@trpc/server@10.45.2':
     resolution: {integrity: sha512-wOrSThNNE4HUnuhJG6PfDRp4L2009KDVxsd+2VYH8ro6o/7/jwYZ8Uu5j+VaW+mOmc8EHerHzGcdbGNQSAUPgg==}
 
+  '@types/d3-array@3.2.1':
+    resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.7':
+    resolution: {integrity: sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/eslint@8.56.12':
     resolution: {integrity: sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==}
 
@@ -1259,6 +1293,50 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.0:
+    resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -1294,6 +1372,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1325,6 +1406,9 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   drizzle-orm@0.33.0:
     resolution: {integrity: sha512-SHy72R2Rdkz0LEq0PSG/IdvnT3nGiWuRk+2tXZQ90GVq/XQhpCzu/EFT3V2rox+w8MlkBQxifF8pCStNYnERfA==}
@@ -1580,8 +1664,15 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.2.2:
+    resolution: {integrity: sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -1745,6 +1836,10 @@ packages:
   internal-slot@1.0.7:
     resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-array-buffer@3.0.4:
     resolution: {integrity: sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==}
@@ -1940,6 +2035,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -2264,6 +2362,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -2284,6 +2385,12 @@ packages:
       '@types/react':
         optional: true
 
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -2293,6 +2400,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -2305,9 +2418,22 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.1:
+    resolution: {integrity: sha512-v8PUTUlyiDe56qUj82w/EDVuzEFXwEHp9/xOowGAZwfLjB9uAy3GllQVIYMWF6nU+qibx85WF75zD7AjqoT54Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   reflect.getprototypeof@1.0.6:
     resolution: {integrity: sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==}
     engines: {node: '>= 0.4'}
+
+  regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
   regexp.prototype.flags@1.5.3:
     resolution: {integrity: sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==}
@@ -2511,6 +2637,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -2596,6 +2725,9 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
+
   which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
 
@@ -2654,6 +2786,10 @@ snapshots:
       oauth4webapi: 3.3.0
       preact: 10.24.3
       preact-render-to-string: 6.5.11(preact@10.24.3)
+
+  '@babel/runtime@7.26.10':
+    dependencies:
+      regenerator-runtime: 0.14.1
 
   '@emnapi/runtime@1.3.1':
     dependencies:
@@ -3384,6 +3520,30 @@ snapshots:
 
   '@trpc/server@10.45.2': {}
 
+  '@types/d3-array@3.2.1': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.7':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/eslint@8.56.12':
     dependencies:
       '@types/estree': 1.0.6
@@ -3709,6 +3869,44 @@ snapshots:
 
   csstype@3.1.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.0: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.0
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-view-buffer@1.0.1:
@@ -3738,6 +3936,8 @@ snapshots:
   debug@4.3.7:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   deep-is@0.1.4: {}
 
@@ -3769,6 +3969,11 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.26.10
+      csstype: 3.1.3
 
   drizzle-orm@0.33.0(@types/react@18.3.12)(postgres@3.4.5)(react@18.3.1):
     optionalDependencies:
@@ -4088,7 +4293,11 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@4.0.7: {}
+
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.2.2: {}
 
   fast-glob@3.3.1:
     dependencies:
@@ -4269,6 +4478,8 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.0.6
 
+  internmap@2.0.3: {}
+
   is-array-buffer@3.0.4:
     dependencies:
       call-bind: 1.0.7
@@ -4447,6 +4658,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
+
+  lodash@4.17.21: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -4694,6 +4907,8 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@18.3.1: {}
+
   react-remove-scroll-bar@2.3.8(@types/react@18.3.12)(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -4713,6 +4928,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.12
 
+  react-smooth@4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      fast-equals: 5.2.2
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
   react-style-singleton@2.2.3(@types/react@18.3.12)(react@18.3.1):
     dependencies:
       get-nonce: 1.0.1
@@ -4720,6 +4943,15 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.12
+
+  react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.26.10
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react@18.3.1:
     dependencies:
@@ -4733,6 +4965,23 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.17.21
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
+
   reflect.getprototypeof@1.0.6:
     dependencies:
       call-bind: 1.0.7
@@ -4742,6 +4991,8 @@ snapshots:
       get-intrinsic: 1.2.4
       globalthis: 1.0.4
       which-builtin-type: 1.1.4
+
+  regenerator-runtime@0.14.1: {}
 
   regexp.prototype.flags@1.5.3:
     dependencies:
@@ -5010,6 +5261,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-invariant@1.3.3: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -5102,6 +5355,23 @@ snapshots:
       react: 18.3.1
 
   util-deprecate@1.0.2: {}
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.1
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.7
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   which-boxed-primitive@1.0.2:
     dependencies:

--- a/src/frontend/src/app/usage/components/UsageChart.tsx
+++ b/src/frontend/src/app/usage/components/UsageChart.tsx
@@ -1,0 +1,143 @@
+import React, { useEffect } from "react";
+import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ResponsiveContainer } from "recharts";
+import { Button } from "@/components/ui/button"; // Assuming you're using shadcn/ui
+import { UsageTooltip } from "./UsageTooltip";
+import { Skeleton } from "~/components/ui/skeleton";
+import { set } from "zod";
+import { trpcReact } from "~/trpc/trpc-react";
+import { LineDot } from "recharts/types/cartesian/Line";
+
+export interface UsageChartProps {
+  data: any[];
+  dataLoading: boolean;
+}
+
+export function UsageChart() {
+
+  // Get Metric
+  const [metric, setMetric] = React.useState<'count' | 'msEllapsed' | 'estimatedCost'>('estimatedCost');
+  const [timeframe, setTimeframe] = React.useState<'week' | 'month' | 'year'>('week');
+
+  // Load the Data
+  const { data, isLoading, error } =
+    timeframe === "week"
+      ? trpcReact.usage.getWeekDailyUsage.useQuery({})
+      : trpcReact.usage.getMonthDailyUsage.useQuery({});
+
+  // Decide scale
+  const max = data && Math.max(...data.map((d) => {
+    if (typeof (d[metric]) === 'number') {
+      return d[metric]
+    }
+    return Math.ceil(parseFloat(d[metric]));
+  }
+  ));
+  const ydomain = data && [0, max ? max : 0];
+
+  const dateTickFormatter = (date: string) => {
+
+    if (timeframe === 'week') {
+      const dayOfWeek = new Date(date).toLocaleString("default", { weekday: "short" });
+      return dayOfWeek;
+    }
+
+    const [year, month, day] = date.split("-");
+    if (!year || !month || !day) return date;
+
+    const shortMonth = new Date(parseInt(year), parseInt(month) - 1).toLocaleString("default", { month: "short" });
+    const out = `${shortMonth}. ${parseInt(day)}`;
+
+    console.log(out, date)
+
+    return out;
+  }
+
+  return (
+    <div className="p-1 px-[50px]">
+      {/* Buttons */}
+      <div className={`flex ${window.innerWidth < 768 ? 'flex-col' : 'justify-between'} mt-4 gap-2 w-full`}>
+
+        <div className="flex flex-col justify-center align-center">
+          <div className="font-semibold pb-2">
+            Time Span
+          </div>
+          <div className="flex gap-2">
+            {/* <Button variant={timeframe === 'year' ? "default" : 'outline'} onClick={() => setTimeframe('year')}>This Year</Button> */}
+            <Button variant={timeframe === 'month' ? "default" : 'outline'} onClick={() => setTimeframe('month')}>This Month</Button>
+            <Button variant={timeframe === 'week' ? "default" : 'outline'} onClick={() => setTimeframe('week')}>This Week</Button>
+          </div>
+        </div>
+
+        <div className="flex flex-col justify-center align-center">
+          <div className="font-semibold pb-2">
+            Metric
+          </div>
+          <div className='flex gap-2'>
+            <Button
+              variant={metric === 'estimatedCost' ? "default" : 'outline'}
+              onClick={() => setMetric('estimatedCost')}
+            >
+              Estimated Costs
+            </Button>
+            <Button
+              variant={metric === 'count' ? "default" : 'outline'}
+              onClick={() => setMetric('count')}
+            >
+              Bots Created
+            </Button>
+            <Button
+              variant={metric === 'msEllapsed' ? "default" : 'outline'}
+              onClick={() => setMetric('msEllapsed')}
+            >
+              Active Bot Time
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Chart */}
+      <div className="mt-6">
+        {data && data.length > 0
+          ?
+          <ResponsiveContainer width="100%" height={300}>
+            <LineChart data={data}>
+              <CartesianGrid strokeDasharray="3 3" />
+
+              <XAxis
+                dataKey="date"
+                tickFormatter={dateTickFormatter} // Format YYYY-MM-DD 
+              />
+
+              <YAxis
+                domain={ydomain}
+                allowDecimals={false}
+                tickFormatter={metric === 'msEllapsed' ? (value) => (value / 60000).toFixed(2) : undefined}
+              />
+
+              <Tooltip content={<UsageTooltip metric={metric} />} />
+
+              {/* Define the Line */}
+              <Line
+                type="monotone"
+                dataKey={metric}
+                stroke="#6366f1"
+                strokeWidth={2}
+                dot={{ r: 0 }}
+                activeDot={{ r: 6 }}
+                animationDuration={500}  // Speed up animation (default is 1500)
+              />
+            </LineChart>
+          </ResponsiveContainer>
+          :
+          (isLoading || !data ?
+            <Skeleton className="mt-2 h-[300px] w-100" />
+            :
+            <div>
+              No Data
+            </div>
+          )
+        }
+      </div>
+    </div>
+  );
+};

--- a/src/frontend/src/app/usage/components/UsageTooltip.tsx
+++ b/src/frontend/src/app/usage/components/UsageTooltip.tsx
@@ -1,0 +1,71 @@
+export interface UsageTooltipProps {
+    active?: boolean;
+    payload?: {payload: any}[];
+    label?: string;
+    metric: string
+}
+
+export const UsageTooltip = ({ active, payload, label, metric }: UsageTooltipProps) => {
+    if (!active || !payload || !payload.length) return null;
+    const objData = payload[0]?.payload;
+    if (!objData) return null;
+
+    // Render
+    const activeMutation = 'font-semibold text-lg'
+    const checkActive = (check: string) => (metric === check ? activeMutation : '');
+ 
+    // Format
+    const formatDuration = (ms: number): string => {
+      if (ms < 1000) return `${ms} ms`;
+
+      const seconds = ms / 1000;
+      if (seconds < 60) return `${seconds.toFixed(1)} seconds`;
+
+      const minutes = Math.floor(ms / 60000);
+      const subSeconds = Math.floor((ms % 60000) / 1000);
+
+      if (minutes < 60) return `${minutes} minutes ${subSeconds} seconds`;
+
+      const hours = Math.floor(minutes / 60);
+      const remainingMinutes = minutes % 60;
+      return `${hours} hours ${remainingMinutes} minutes`;
+    };
+
+    // Format Date
+    const formatDate = (dateString: string | undefined): string => {
+
+      if (!dateString) return 'Unknown Date';
+
+      const date = new Date(dateString);
+      const options: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'long', day: 'numeric' };
+      const formattedDate = date.toLocaleDateString(undefined, options);
+
+      const day = date.getDate() + 1;
+      const suffix =
+        day % 10 === 1 && day !== 11
+          ? 'st'
+          : day % 10 === 2 && day !== 12
+          ? 'nd'
+          : day % 10 === 3 && day !== 13
+          ? 'rd'
+          : 'th';
+
+      return formattedDate.replace(/\d+/, `${day}${suffix}`);
+    };
+
+    return (
+      <div className="bg-white shadow-md p-3 rounded-md border">
+        <p className="font-semibold pb-2">{formatDate(label)}</p>
+
+        <p className={`text-blue-600 pb-2 ${checkActive('estimatedCost')}`}>
+          Estimated Cost: ${objData.estimatedCost}</p>
+
+        <p className={`text-grey-500 ${checkActive('count')}`}>
+            Bots Used: {objData.count}</p>
+
+        <p className={`text-grey-600 ${checkActive('msEllapsed')}`}>
+          Total Time: {formatDuration(objData.msEllapsed)}</p>
+
+      </div>
+    );
+  };

--- a/src/frontend/src/app/usage/page.tsx
+++ b/src/frontend/src/app/usage/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { trpcReact } from "~/trpc/trpc-react";
+import { UsageChart } from "./components/UsageChart";
+import ErrorAlert from "../components/ErrorAlert";
+
+export default function Keys() {
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">Usage</h2>
+          <p className="text-muted-foreground">
+            Track your bot usage
+          </p>
+        </div>
+      </div>
+
+      <UsageChart />
+    </div>
+  );
+}


### PR DESCRIPTION
### TL;DR

Added a usage tracking dashboard with interactive charts to visualize bot usage metrics over different time periods.

Completes MEE-176

### What changed?

- Enhanced the `dailyUsageSchema` to include `estimatedCost` field
- Created new TRPC endpoints for usage data:
  - `getAllUsage`: Retrieves usage data for all time
  - `getWeekDailyUsage`: Gets daily usage for the current week
  - `getMonthDailyUsage`: Gets daily usage for the current month
- Added a utility function `formatDayUsageDictToOutput` to standardize data formatting
- Implemented a new usage dashboard UI with:
  - Interactive charts using Recharts library
  - Filters for different time periods (week/month)
  - Ability to switch between different metrics (estimated cost, bot count, active time)
  - Custom tooltips showing detailed information

### How to test?

1. Navigate to the `/usage` page in the application
2. Toggle between "This Week" and "This Month" to view different time periods
3. Switch between metrics (Estimated Costs, Bots Created, Active Bot Time)
4. Hover over data points to see detailed information in tooltips
5. Verify that empty days are properly displayed and data is sorted chronologically

### Why make this change?

This change provides users with better visibility into their bot usage patterns and associated costs. The interactive dashboard helps users track their resource consumption over time, understand usage trends, and make informed decisions about their bot deployments. The estimated cost calculation gives users a clearer picture of their spending, which is valuable for budget planning and resource allocation.