### PR TITLE
refactor: set image urls and app name as TF variables

### DIFF
--- a/src/terraform/.gitignore
+++ b/src/terraform/.gitignore
@@ -1,4 +1,4 @@
 .terraform
 .infracost
 
-backend.tfvars
+*.tfvars

--- a/src/terraform/ecs.tf
+++ b/src/terraform/ecs.tf
@@ -137,19 +137,13 @@ resource "aws_ecs_task_definition" "frontend" {
   container_definitions = jsonencode([
     {
       name      = "frontend"
-      image     = var.frontend_image_url
+      image     = var.frontend_image_url != "" ? var.frontend_image_url : "ghcr.io/meetingbot/frontend:sha-${local.current_commit_sha_short}"
       essential = true
       portMappings = [
         {
           containerPort = local.frontend_port
           hostPort      = local.frontend_port
           protocol      = "tcp"
-        }
-      ]
-      environment = [
-        {
-          name = "NEXT_PUBLIC_BACKEND_URL"
-          value = "https://${var.domain_name}/api"
         }
       ]
 
@@ -200,7 +194,7 @@ resource "aws_ecs_task_definition" "backend" {
   container_definitions = jsonencode([
     {
       name      = "backend"
-      image     = var.backend_image_url
+      image     = var.backend_image_url != "" ? var.backend_image_url : "ghcr.io/meetingbot/backend:sha-${local.current_commit_sha_short}"
       essential = true
       portMappings = [
         {
@@ -344,7 +338,7 @@ resource "aws_ecs_task_definition" "meet_bot" {
   container_definitions = jsonencode([
     {
       name      = "bot"
-      image     = var.meet_bot_image_url
+      image     = var.meet_bot_image_url != "" ? var.meet_bot_image_url : "ghcr.io/meetingbot/bots/meet:sha-${local.current_commit_sha_short}"
       essential = true
       environment = [
         {
@@ -386,7 +380,7 @@ resource "aws_ecs_task_definition" "zoom_bot" {
   container_definitions = jsonencode([
     {
       name      = "bot"
-      image     = var.zoom_bot_image_url
+      image     = var.zoom_bot_image_url != "" ? var.zoom_bot_image_url : "ghcr.io/meetingbot/bots/zoom:sha-${local.current_commit_sha_short}"
       essential = true
       environment = [
         {
@@ -428,7 +422,7 @@ resource "aws_ecs_task_definition" "teams_bot" {
   container_definitions = jsonencode([
     {
       name      = "bot"
-      image     = var.teams_bot_image_url
+      image     = var.teams_bot_image_url != "" ? var.teams_bot_image_url : "ghcr.io/meetingbot/bots/teams:sha-${local.current_commit_sha_short}"
       essential = true
       environment = [
         {

--- a/src/terraform/ecs.tf
+++ b/src/terraform/ecs.tf
@@ -146,6 +146,12 @@ resource "aws_ecs_task_definition" "frontend" {
           protocol      = "tcp"
         }
       ]
+      environment = [
+        {
+          name = "NEXT_PUBLIC_BACKEND_URL"
+          value = "https://${var.domain_name}/api"
+        }
+      ]
 
       logConfiguration = {
         logDriver = "awslogs"

--- a/src/terraform/ecs.tf
+++ b/src/terraform/ecs.tf
@@ -137,7 +137,7 @@ resource "aws_ecs_task_definition" "frontend" {
   container_definitions = jsonencode([
     {
       name      = "frontend"
-      image     = "ghcr.io/meetingbot/frontend:sha-${local.current_commit_sha_short}"
+      image     = var.frontend_image_url
       essential = true
       portMappings = [
         {
@@ -194,7 +194,7 @@ resource "aws_ecs_task_definition" "backend" {
   container_definitions = jsonencode([
     {
       name      = "backend"
-      image     = "ghcr.io/meetingbot/backend:sha-${local.current_commit_sha_short}"
+      image     = var.backend_image_url
       essential = true
       portMappings = [
         {
@@ -338,7 +338,7 @@ resource "aws_ecs_task_definition" "meet_bot" {
   container_definitions = jsonencode([
     {
       name      = "bot"
-      image     = "ghcr.io/meetingbot/bots/meet:sha-${local.current_commit_sha_short}"
+      image     = var.meet_bot_image_url
       essential = true
       environment = [
         {
@@ -380,7 +380,7 @@ resource "aws_ecs_task_definition" "zoom_bot" {
   container_definitions = jsonencode([
     {
       name      = "bot"
-      image     = "ghcr.io/meetingbot/bots/zoom:sha-${local.current_commit_sha_short}"
+      image     = var.zoom_bot_image_url
       essential = true
       environment = [
         {
@@ -422,7 +422,7 @@ resource "aws_ecs_task_definition" "teams_bot" {
   container_definitions = jsonencode([
     {
       name      = "bot"
-      image     = "ghcr.io/meetingbot/bots/teams:sha-${local.current_commit_sha_short}"
+      image     = var.teams_bot_image_url
       essential = true
       environment = [
         {

--- a/src/terraform/main.tf
+++ b/src/terraform/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
   profile = var.aws_profile
   default_tags {
     tags = {
-      app-id      = "meetingbot"
+      app-id      = var.app_name
       app-purpose = "Self-hosted meeting bot API"
       environment = terraform.workspace
       pii         = "yes"
@@ -14,11 +14,9 @@ provider "aws" {
 data "aws_availability_zones" "available" {}
 
 locals {
-  name = "meetingbot-${terraform.workspace}"
+  name = "${var.app_name}-${terraform.workspace}"
 
   azs = slice(data.aws_availability_zones.available.names, 0, 3)
-
-  current_commit_sha_short = substr(trimspace(file("../../.git/${trimspace(trimprefix(file("../../.git/HEAD"), "ref:"))}")), 0, 7)
 
   prod = terraform.workspace == "prod"
 }

--- a/src/terraform/main.tf
+++ b/src/terraform/main.tf
@@ -18,6 +18,8 @@ locals {
 
   azs = slice(data.aws_availability_zones.available.names, 0, 3)
 
+  current_commit_sha_short = substr(trimspace(file("../../.git/${trimspace(trimprefix(file("../../.git/HEAD"), "ref:"))}")), 0, 7)
+
   prod = terraform.workspace == "prod"
 }
 

--- a/src/terraform/terraform.tfvars
+++ b/src/terraform/terraform.tfvars
@@ -1,6 +1,0 @@
-aws_profile = "meetingbot"
-aws_region  = "us-east-2"
-domain_name = "app.meetingbot.tech"
-
-auth_github_id = "Iv23liG4ScAzXhYu96F0"
-auth_github_secret = "8aca0c3d462afb2c408f900cfcdbc58bf48290bd"

--- a/src/terraform/terraform.tfvars.example
+++ b/src/terraform/terraform.tfvars.example
@@ -1,3 +1,12 @@
 aws_profile = "meetingbot"
 aws_region  = "us-east-2"
 domain_name = "app.meetingbot.tech"
+app_name = "meetingbot"
+auth_github_id = ""
+auth_github_secret = ""
+frontend_image_url = ""
+backend_image_url = ""
+meet_bot_image_url = ""
+zoom_bot_image_url = ""
+teams_bot_image_url = ""
+

--- a/src/terraform/variables.tf
+++ b/src/terraform/variables.tf
@@ -9,6 +9,11 @@ variable "aws_region" {
   nullable    = true
 }
 
+variable "app_name" {
+  type        = string
+  description = "The name of the application"
+}
+
 variable "domain_name" {
   type        = string
   description = "The domain name to use for the website"
@@ -24,4 +29,29 @@ variable "auth_github_secret" {
   type        = string
   description = "The GitHub secret for authentication"
   sensitive   = true
+}
+
+variable "meet_bot_image_url" {
+  type        = string
+  description = "The Docker image to use for the Google Meet bot"
+}
+
+variable "zoom_bot_image_url" {
+  type        = string
+  description = "The Docker image to use for the Zoom bot"
+}
+
+variable "teams_bot_image_url" {
+  type        = string
+  description = "The Docker image to use for the Teams bot"
+}
+
+variable "frontend_image_url" {
+  type        = string
+  description = "The Docker image to use for the frontend"
+}
+
+variable "backend_image_url" {
+  type        = string
+  description = "The Docker image to use for the backend"
 }

--- a/src/terraform/variables.tf
+++ b/src/terraform/variables.tf
@@ -34,24 +34,29 @@ variable "auth_github_secret" {
 variable "meet_bot_image_url" {
   type        = string
   description = "The Docker image to use for the Google Meet bot"
+  default     = ""
 }
 
 variable "zoom_bot_image_url" {
   type        = string
   description = "The Docker image to use for the Zoom bot"
+  default     = ""
 }
 
 variable "teams_bot_image_url" {
   type        = string
   description = "The Docker image to use for the Teams bot"
+  default     = ""
 }
 
 variable "frontend_image_url" {
   type        = string
   description = "The Docker image to use for the frontend"
+  default     = ""
 }
 
 variable "backend_image_url" {
   type        = string
   description = "The Docker image to use for the backend"
+  default     = ""
 }


### PR DESCRIPTION
Hi, amazing work on the project so far, I love it! 

I deployed it on my infrastructure and I want to propose changes in Terraform variables that I believe make it easier to have a customized version deployed.

## What changes?
### 1. tfvars become private for custom configuration
### 2. Added new variables for setting the application name and image URLs
- The hardcoded "meetingbot" as the application name causes issues with already existing S3 buckets. 
- The image URLs are there so that forks can deploy their own containers.