### PR TITLE
refactor: remove api path from NEXT_PUBLIC_BACKEND_URL to correct links to docs in front-end

### DIFF
--- a/src/frontend/.env.example
+++ b/src/frontend/.env.example
@@ -9,4 +9,4 @@
 # When adding additional environment variables, the schema in "/src/env.js"
 # should be updated accordingly.
 
-NEXT_PUBLIC_BACKEND_URL="http://localhost:3001/api"
+NEXT_PUBLIC_BACKEND_URL="http://localhost:3001/"

--- a/src/frontend/src/app/components/SessionButton.tsx
+++ b/src/frontend/src/app/components/SessionButton.tsx
@@ -25,7 +25,7 @@ export default function SessionButton() {
   if (!session?.user) {
     return (
       <Link
-        href={`${env.NEXT_PUBLIC_BACKEND_URL}/auth/signin?provider=github`}
+        href={`${env.NEXT_PUBLIC_BACKEND_URL}/api/auth/signin?provider=github`}
       >
         <Button variant="outline" className="gap-2">
           Sign In
@@ -50,9 +50,8 @@ export default function SessionButton() {
       <DropdownMenuContent>
         <DropdownMenuLabel>My Account</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuItem>Profile</DropdownMenuItem>
         <Link
-          href={`${env.NEXT_PUBLIC_BACKEND_URL}/auth/signout`}
+          href={`${env.NEXT_PUBLIC_BACKEND_URL}/api/auth/signout`}
           className="cursor-pointer"
         >
           <DropdownMenuItem>Logout</DropdownMenuItem>

--- a/src/frontend/src/contexts/SessionContext.tsx
+++ b/src/frontend/src/contexts/SessionContext.tsx
@@ -26,7 +26,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   async function getSession(): Promise<Session | null> {
     try {
       const response = await fetch(
-        `${env.NEXT_PUBLIC_BACKEND_URL}/auth/session`,
+        `${env.NEXT_PUBLIC_BACKEND_URL}/api/auth/session`,
         {
           credentials: "include",
           headers: {

--- a/src/frontend/src/trpc/trpc-react.tsx
+++ b/src/frontend/src/trpc/trpc-react.tsx
@@ -37,7 +37,7 @@ export function TRPCProvider(
       transformer: superjson,
       links: [
         httpBatchLink({
-          url: `${env.NEXT_PUBLIC_BACKEND_URL}/trpc`,
+          url: `${env.NEXT_PUBLIC_BACKEND_URL}/api/trpc`,
           fetch(url, options) {
             return fetch(url, {
               ...options,

--- a/src/frontend/src/trpc/trpc-vanilla.tsx
+++ b/src/frontend/src/trpc/trpc-vanilla.tsx
@@ -7,7 +7,7 @@ export const trpcVanilla = createTRPCProxyClient<AppRouter>({
   transformer: superjson,
   links: [
     httpBatchLink({
-      url: `${env.NEXT_PUBLIC_BACKEND_URL}/trpc`,
+      url: `${env.NEXT_PUBLIC_BACKEND_URL}/api/trpc`,
       fetch(url, options) {
         return fetch(url, {
           ...options,


### PR DESCRIPTION
When we changed the `NEXT_PUBLIC_BACKEND_URL` to `/api`, the `/docs` links broke. Here, I am changing it *back*, then adding the `/api` when necessary.

We need to update our env variables in terraform maybe? @err53 

towards MEE-175