### PR TITLE
fix(backend/bots): pass callbackUrl from input to db

### DIFF
--- a/src/backend/src/routers/bots.ts
+++ b/src/backend/src/routers/bots.ts
@@ -85,6 +85,7 @@ export const botsRouter = createTRPCRouter({
             input.heartbeatInterval ?? DEFAULT_BOT_VALUES.heartbeatInterval,
           automaticLeave:
             input.automaticLeave ?? DEFAULT_BOT_VALUES.automaticLeave,
+          callbackUrl: input.callbackUrl ?? null,
         }
 
         const result = await ctx.db.insert(bots).values(dbInput).returning()


### PR DESCRIPTION
Callbacks don't work currently because they're not passed to the DB when creating a bot. 

Question, shouldn't we pass the whole input to the db and have defaults handled in the zod schema?