### PR TITLE
fix: added callbackUrl

### DIFF
--- a/src/backend/src/routers/bots.ts
+++ b/src/backend/src/routers/bots.ts
@@ -85,6 +85,7 @@ export const botsRouter = createTRPCRouter({
             input.heartbeatInterval ?? DEFAULT_BOT_VALUES.heartbeatInterval,
           automaticLeave:
             input.automaticLeave ?? DEFAULT_BOT_VALUES.automaticLeave,
+          callbackUrl: input.callbackUrl, // Credit to @martinezpl for this line -- cannot merge at time of writing due to capstone requirements
         }
 
         const result = await ctx.db.insert(bots).values(dbInput).returning()


### PR DESCRIPTION
### TL;DR

Added support for callback URL when creating bots.

### What changed?

Added a `callbackUrl` field to the bot creation process in the `botsRouter`. This allows users to specify a URL that will be called when certain bot events occur.

### How to test?

1. Create a new bot with a callback URL parameter
2. Verify the callback URL is saved correctly in the database
3. Confirm that the bot events trigger calls to the specified URL

### Why make this change?

This enhancement enables webhook functionality for bots, allowing for integration with external systems. The callback URL can be used to notify external services about bot events, enabling more complex automation workflows and integrations.