### PR TITLE
feat: example app WORKING (proper env var)

### DIFF
--- a/src/backend/request_testing.http
+++ b/src/backend/request_testing.http
@@ -96,3 +96,19 @@ x-api-key: 0bc3598273e72800afa66146686c2c5d28cff0aa76f9381b3fd59651e63b4000
 GET http://127.0.0.1:3001/api/usage/day
 content-type: application/json
 x-api-key: 0bc3598273e72800afa66146686c2c5d28cff0aa76f9381b3fd59651e63b4000
+
+###
+
+# Check Bot Usage
+POST https://d531-184-146-60-163.ngrok-free.app/api/callback
+content-type: application/json
+
+{
+  "botId": 36
+}
+
+###
+
+# Get bots
+GET http://app.meetingbot.tech/api/bots/40
+x-api-key: 559b52c91b258c44b0c90ea43e3e914a21aa96079e72941635310298b864ea57

--- a/src/example-app/.env.example
+++ b/src/example-app/.env.example
@@ -1,3 +1,3 @@
 BOT_API_KEY=""
 MEETINGBOT_END_POINT="http://localhost:3001" # Replace with the endpoint of your meeting bot application on AWS
-CALLBACK_URL="https://localhost:3002/api/callback" # Replace with the endpoint of your callback URL in your appliation -- we are assuming that this example app runs on 3002 locally.
+NEXT_PUBLIC_CALLBACK_URL="https://localhost:3002/api/callback" # Replace with the endpoint of your callback URL in your appliation -- we are assuming that this example app runs on 3002 locally.

--- a/src/terraform/.terraform.lock.hcl
+++ b/src/terraform/.terraform.lock.hcl
@@ -2,8 +2,7 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.84.0"
-  constraints = ">= 3.29.0, >= 4.40.0, >= 5.37.0, >= 5.46.0, >= 5.59.0, >= 5.62.0, >= 5.82.0"
+  version = "5.84.0"
   hashes = [
     "h1:EJLTu1eqP93P4+DexFZHnuMCwEapkmHhEUirUT+tjZw=",
     "h1:OJ53RNte7HLHSMxSkzu1S6H8sC0T8qnCAOcNLjjtMpc=",
@@ -28,6 +27,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.7.1"
   hashes = [
+    "h1:Jvr+8mqBJlxSOF8R862ZtezBlCb9pVwNMNc1sYsDeYg=",
     "h1:t152MY0tQH4a8fLzTtEWx70ITd3azVOrFDn/pQblbto=",
     "zh:3193b89b43bf5805493e290374cdda5132578de6535f8009547c8b5d7a351585",
     "zh:3218320de4be943e5812ed3de995946056db86eb8d03aa3f074e0c7316599bef",


### PR DESCRIPTION
### TL;DR

Improved Zoom meeting link parsing and updated environment variable naming for callback URL.

### What changed?

- Enhanced the Zoom meeting link regex pattern to properly validate Zoom URLs with subdomains and password parameters
- Added a `parseZoomMeetingLink` function to extract meeting ID and password from Zoom URLs
- Updated environment variable from `CALLBACK_URL` to `NEXT_PUBLIC_CALLBACK_URL` in the example app
- Added new API testing endpoints in the request_testing.http file for bot usage and retrieval
- Implemented the Zoom meeting link parsing logic in the MeetingBotCreator component

### How to test?

1. Test the improved Zoom link validation with various formats:
   - Links with subdomains (e.g., `https://company.zoom.us/j/123456789`)
   - Links with password parameters (e.g., `https://zoom.us/j/123456789?pwd=abc123`)
2. Verify the callback functionality works with the new environment variable name
3. Try the new API endpoints in the request_testing.http file

### Why make this change?

The previous Zoom link validation was too restrictive and didn't properly handle the variety of Zoom meeting URL formats. This change improves the user experience by accepting more valid Zoom meeting links and correctly extracting the meeting ID and password parameters. The environment variable rename to include `NEXT_PUBLIC_` prefix makes it accessible on the client side in Next.js applications.