### PR TITLE
refactor: bots-testable-run-functions

### DIFF
--- a/src/bots/src/bot.ts
+++ b/src/bots/src/bot.ts
@@ -6,6 +6,7 @@ export interface BotInterface {
   getRecordingPath(): string;
   getContentType(): string;
   run(): Promise<void>;
+  screenshot(fName?: string): Promise<void>;
 }
 
 export class Bot implements BotInterface {
@@ -20,14 +21,55 @@ export class Bot implements BotInterface {
     this.onEvent = onEvent;
   }
 
+  /**
+   * Open a browser and navigatges, joins the meeting.
+   */  
+  async joinMeeting(): Promise<any> {
+    throw new Error("Method not implemented.");
+  }
+
+
+  /**
+   * Takes a screenshot of the current page and saves it to a file. Useful for debugging..
+   * @param fName - The name of the file to save the screenshot as.
+   */
+  async screenshot(fName?: string): Promise<void> {
+      throw new Error("Method not implemented.");
+  }
+
+  /**
+   *  Clean Resources, close the browser.
+   * This is used differently by each bot, but it should be called
+   * at the end of the bot's lifecycle at some point.
+   * 
+   * Helpful in testing, where a bot might not be able to close the browser
+   * due to a different lifecycle, or the test ending.
+   * @returns {Promise<void>}
+   */  
+  async endLife(): Promise<any> {
+    throw new Error("Method not implemented.");
+  }
+
+  /**
+   * Run the platform specific bot. Joins meeting, Sets up recording,
+   * and waits to leave -- then leaves.
+   */
   async run(): Promise<void> {
     throw new Error("Method not implemented.");
   }
 
+  /**
+   * Function to get the recordingPath
+   * @returns {string} recordingPath
+   */
   getRecordingPath(): string {
     throw new Error("Method not implemented.");
   }
 
+  /**
+   * Function to get the contnet type of the recording
+   * @returns {string} contentType
+   */
   getContentType(): string {
     throw new Error("Method not implemented.");
   }

--- a/src/bots/src/index.ts
+++ b/src/bots/src/index.ts
@@ -78,7 +78,7 @@ const main = async () => {
 
   // Start heartbeat in the background
   console.log("Starting heartbeat");
-  // startHeartbeat(botId, heartbeatController.signal);
+  startHeartbeat(botId, heartbeatController.signal);
 
   // Report READY_TO_DEPLOY event
   await reportEvent(botId, EventCode.READY_TO_DEPLOY);
@@ -86,10 +86,17 @@ const main = async () => {
   try {
     // Run the bot
     await bot.run().catch(async (error) => {
+
       console.error("Error running bot:", error);
       await reportEvent(botId, EventCode.FATAL, {
         description: (error as Error).message,
       });
+
+      // Check what's on the screen in case of an error
+      bot.screenshot();
+
+      // **Ensure** the bot cleans up its resources after a breaking error
+      await bot.endLife();
     });
 
     // Upload recording to S3

--- a/src/bots/src/types.ts
+++ b/src/bots/src/types.ts
@@ -53,3 +53,10 @@ export enum EventCode {
   PARTICIPANT_LEAVE = "PARTICIPANT_LEAVE",
   LOG = "LOG",
 }
+
+export class WaitingRoomTimeoutError extends Error {
+  constructor(message: string = "The ") {
+    super(message);
+    this.name = "WaitingRoomTimeoutError";
+  }
+}

--- a/src/bots/zoom/src/bot.ts
+++ b/src/bots/zoom/src/bot.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import puppeteer from "puppeteer";
+import puppeteer, { Page, Frame } from "puppeteer";
 import { launch, getStream, wss } from "puppeteer-stream";
 import { BotConfig, EventCode } from "../../src/types";
 import { Bot } from "../../src/bot";
@@ -10,11 +10,15 @@ const muteButton = 'button[aria-label="Mute"]';
 const stopVideoButton = 'button[aria-label="Stop Video"]';
 const joinButton = 'button.zm-btn.preview-join-button';
 const leaveButton = 'button[aria-label="Leave"]';
+import { Browser } from "puppeteer";
 
 export class ZoomBot extends Bot {
   recordingPath: string;
   contentType: string;
   url: string;
+  browser!: Browser;
+  page!: Page;
+  file!: fs.WriteStream;
 
   constructor(
     botSettings: BotConfig,
@@ -26,11 +30,29 @@ export class ZoomBot extends Bot {
     this.url = `https://app.zoom.us/wc/${this.settings.meetingInfo.meetingId}/join?fromPWA=1&pwd=${this.settings.meetingInfo.meetingPassword}`;
   }
 
-  async run() {
-    const file = fs.createWriteStream(this.recordingPath);
+
+  async screenshot(fName: string = "screenshot.png") {
+    if (!this.page) throw new Error("Page not initialized");
+    const screenshot = await this.page.screenshot({
+      type: "png",
+      encoding: "binary",
+    });
+
+    // Save the screenshot to a file
+    const screenshotPath = `./${fName}`;
+    fs.writeFileSync(screenshotPath, screenshot);
+    console.log(`Screenshot saved to ${screenshotPath}`);
+  }
+
+
+  /**
+   * Opens a browser and navigatges, joins the meeting.
+   * @returns {Promise<void>}
+   */
+  async joinMeeting() {
 
     // Launch a browser and open the meeting
-    const browser = await launch({
+    this.browser = await launch({
       executablePath: puppeteer.executablePath(),
       headless: "new",
       args: [
@@ -39,21 +61,22 @@ export class ZoomBot extends Bot {
         "--use-fake-device-for-media-stream",
         // "--use-fake-ui-for-media-stream"
       ],
-    });
+    }) as unknown as Browser; // It looks like theres a type issue with puppeteer.
 
     // Create a URL object from the url
     const urlObj = new URL(this.url);
 
     // Get the default browser context
-    const context = browser.defaultBrowserContext();
+    const context = this.browser.defaultBrowserContext();
 
     // Clear permission overrides and set our own to camera and microphone
     // This is to avoid the allow microphone and camera prompts
     context.clearPermissionOverrides();
     context.overridePermissions(urlObj.origin, ["camera", "microphone"]);
 
-    // Opens a new browser tab
-    const page = await browser.newPage();
+    // Opens a new page
+    const page = await this.browser.newPage();
+    this.page = page;
 
     // Navigates to the url
     await page.goto(urlObj.href);
@@ -88,39 +111,65 @@ export class ZoomBot extends Bot {
       await frame.click(joinButton);
       console.log("Joined the meeting");
 
-      // Wait for the leave button to appear and be properly labeled before starting recording
+      // Wait for the leave button to appear and be properly labeled before proceeding
       await new Promise((resolve) => setTimeout(resolve, 1400)); // Needed to wait for the aria-label to be properly attached
       await frame.waitForSelector(leaveButton);
       console.log("Leave button found and labeled, ready to start recording");
     }
+  }
 
-    // Start the recording
-    const stream = await getStream(page, { audio: true, video: true });
+  async run() {
+
+    // Navigate and join the meeting.
+    await this.joinMeeting();
+
+    // Ensure browser exists
+    if (!this.browser)
+      throw new Error("Browser not initialized");
+
+    if (!this.page)
+      throw new Error("Page is not initialized");
+
+    // Start the recording -- again, type issue from importing.
+    const stream = await getStream(this.page as any, { audio: true, video: true });
+
+    // Create and Write the recording to a file, pipe the stream to a fileWriteStream
+    this.file = fs.createWriteStream(this.recordingPath);
+    stream.pipe(this.file);
+
     console.log("Recording...");
 
-    // Pipe the stream to the file
-    stream.pipe(file);
+    // Get the Frame containing the meeting
+    const iframe = await this.page.waitForSelector(".pwa-webclient__iframe");
+    const frame = await iframe?.contentFrame();
 
     // Constantly check if the meeting has ended every second
     const checkMeetingEnd = async () => {
+
+      // TODO: Refactor this -- it won't work as expected.
+      // Check for the ok button with a short timeout, and then retry as intentned.
+      // Currently the bot will wait for the button to appear within 1 hour  (360k ms). 
+      // When it appears, then the bot will end the meeting regardless. (no need to check okButton)
+      // If the button does not appear within the hour, it throws TimeoutError, ending the meeting.
+
       // Wait for the "Ok" button to appear which indicates the meeting is over
       const okButton = await frame?.waitForSelector(
         "button.zm-btn.zm-btn-legacy.zm-btn--primary.zm-btn__outline--blue",
-        { timeout: 3600000 }
+        { timeout: 3600000 },
       );
 
       if (okButton) {
         console.log("Meeting ended");
+
         // Click the button to leave the meeting
         await okButton.click();
 
         // End the recording and close the file
         stream.destroy();
-        file.close();
 
-        // Close the browser
-        await browser.close();
-        (await wss).close();
+        // End Life -- Close file, browser, and websocket server
+        this.endLife();
+
       } else {
         setTimeout(checkMeetingEnd, 1000); // Check every second
       }
@@ -138,5 +187,26 @@ export class ZoomBot extends Bot {
   // Get the content type of the recording file
   getContentType(): string {
     return this.contentType;
+  }
+
+  /**
+   * Clean Resources, close the browser.
+   * Ensure the filestream is closed as well.
+   */
+  async endLife() {
+
+    // Close File if it exists
+    if (this.file) {
+      this.file.close();
+      this.file = null as any;
+    }
+
+    // Close Browser
+    if (this.browser) {
+      await this.browser.close();
+
+      // Close the websocket server
+      (await wss).close();
+    }
   }
 }


### PR DESCRIPTION
### TL;DR

Improved bot lifecycle management with proper resource cleanup and error handling.

### What changed?

- Added `endLife()` method to all bots to ensure proper cleanup of resources (browser, file streams, etc.)
- Standardized bot interface with required methods in the base `Bot` class
- Improved error handling for waiting room timeouts with a specific `WaitingRoomTimeoutError`
- Refactored `joinMeeting()` and `leaveMeeting()` methods to better separate concerns
- Updated documentation for bot methods
- Updated Zoom bot dependencies to version 23.11.1

### How to test?

1. Run bots against meetings with waiting rooms to verify proper timeout handling
2. Test error scenarios to ensure resources are properly cleaned up
3. Verify recording functionality works as expected across all platforms
4. Check that browsers are properly closed even when errors occur

### Why make this change?

This change improves resource management and error handling across all bots. By standardizing the bot lifecycle and ensuring proper cleanup, we prevent resource leaks and improve reliability. The separation of concerns between joining, recording, and leaving meetings makes the code more maintainable and easier to debug. The specific error handling for waiting room timeouts provides better diagnostics and reporting.