### PR TITLE
refactor: bot-local-testing-url-generator

### DIFF
--- a/src/bots/envBotDataExample.ts
+++ b/src/bots/envBotDataExample.ts
@@ -10,19 +10,13 @@ import { BotConfig } from "./src/types";
 import fs from "fs";
 import path from "path";
 
+// Paste in your meeting URL here
+const url = '<MEETING_URL>';
+
 const botData: BotConfig = {
   id: 1,
   userId: "<USER_ID>",
-  meetingInfo: {
-    meetingId: "<MEETING_ID>",
-    meetingPassword: undefined,
-    meetingUrl: "<MEETING_URL>",
-    organizerId: "<ORGANIZER_ID>",
-    tenantId: "<TENANT_ID>",
-    messageId: undefined,
-    threadId: undefined,
-    platform: "teams", // "teams", "google", "zoom", etc.
-  },
+  meetingInfo: {}, // empty, because we fill it in as expected by parsing the URL (this makes it easy for teams & zoom, which request a specific format)
   meetingTitle: "Test Meeting",
   startTime: new Date(),
   endTime: new Date(),
@@ -37,12 +31,167 @@ const botData: BotConfig = {
   callbackUrl: "<CALLBACK_URL>",
 };
 
+/*
+ * 
+ * AUX FUNCTIONS -- DISREGARD 
+ * 
+ */
+
+//Meeting Check Functions
+const checkMeetBotLink = (link: string) => {
+  return /^((https:\/\/)?meet\.google\.com\/)?[a-z]{3}-[a-z]{4}-[a-z]{3}$/.test(link);
+}
+
+const checkZoomBotLink = (link: string) => {
+  // Match any zoom.us subdomain followed by /j/ and 9-11 digits
+  return /^https:\/\/[a-z0-9]+\.zoom\.us\/j\/[0-9]{9,11}(?:\?pwd=[^&]+)?$/.test(link);
+}
+
+function parseTeamsMeetingLink(url: string) {
+  try {
+    const urlObj = new URL(url);
+    const pathSegments = urlObj.pathname.split('/');
+
+    // Extract meetingId (after "19:meeting_")
+    let meetingId: string | null = null;
+    const meetingSegment = pathSegments.find(segment => segment.startsWith('19%3ameeting_') || segment.startsWith('19:meeting_'));
+    if (meetingSegment) {
+      const s = meetingSegment.split('meeting_')[1];
+      if (!s) return null;
+      meetingId = meetingSegment ? decodeURIComponent(s).split('@')[0] : null;
+    }
+
+    // Extract tenantId and organizationId from context parameter
+    const params = new URLSearchParams(urlObj.search);
+    const context = params.get("context");
+
+    let tenantId = null;
+    let organizationId = null;
+    if (context) {
+      const contextObj = JSON.parse(decodeURIComponent(context));
+      tenantId = contextObj.Tid || null;
+      organizationId = contextObj.Oid || null;
+    }
+
+    console.log('Teams: found: ', meetingId, tenantId, organizationId);
+
+    if (meetingId === null || tenantId === null || organizationId === null) {
+      return null;
+    }
+
+    return { meetingId, tenantId, organizationId };
+  } catch (error) {
+    console.error("Error parsing Teams meeting link:", error);
+    return null;
+  }
+}
+
+const checkTeamsBotLink = (link: string) => {
+  return parseTeamsMeetingLink(link) !== null;
+}
+
+const linkParsers: Record<MeetingType, (link: string) => boolean> = {
+  'meet': checkMeetBotLink,
+  'zoom': checkZoomBotLink,
+  'teams': checkTeamsBotLink,
+}
+
+function parseZoomMeetingLink(url: string) {
+  try {
+    const urlObj = new URL(url);
+    const pathSegments = urlObj.pathname.split('/');
+    const meetingId = pathSegments[pathSegments.length - 1];
+    const meetingPassword = urlObj.searchParams.get('pwd') || '';
+
+    return {
+      meetingId,
+      meetingPassword
+    };
+  } catch (error) {
+    console.error("Error parsing Zoom meeting link:", error);
+    return null;
+  }
+}
+
+type MeetingType = 'meet' | 'zoom' | 'teams';
+const defineMeetingInfo = (link: string) => {
+
+  console.log('Splitting Meeting Link')
+
+  // Check Valid Meeting Link
+  const parseMeetingLink = () => {
+
+    // None -- Link
+    if (!link) return undefined;
+
+    // Check for Bot Type
+    for (const [key, checkFunction] of Object.entries(linkParsers)) {
+      if (checkFunction(link)) {
+        return key as MeetingType;
+      }
+    }
+
+    return undefined;
+  }
+  
+
+  const type = parseMeetingLink();
+  console.log('Detected type', type)
+
+  if (type === 'meet') {
+
+    // Ensure we get a meeting URL
+    if (!link.startsWith('https://meet.google.com/')) link = 'https://meet.google.com/' + link;
+    if (!link.startsWith('https://')) link = 'https://' + link;
+
+    return {
+      meetingUrl: link,
+      platform: 'google',
+    };
+  }
+  // Zoom
+  if (type === 'zoom') {
+    const parsed = parseZoomMeetingLink(link);
+    if (!parsed) return undefined;
+
+    return {
+      platform: 'zoom',
+      meetingId: parsed.meetingId,
+      meetingPassword: parsed.meetingPassword
+    };
+  }
+  // Teams
+  if (type === 'teams') {
+
+    // Fetch
+    const parsed = parseTeamsMeetingLink(link);
+    if (!parsed) return undefined;
+
+    const { meetingId, organizationId, tenantId } = parsed;
+
+    return {
+      platform: "teams",
+      meetingId,
+      organizerId: organizationId,
+      tenantId
+    }
+  }
+  return undefined;
+}
+
+/*
+*
+* END AUX FUNCTIONS
+*
+*/
+
 // Append the botData object to the .env file as a BOT_DATA json variable
 const envFilePath = path.join(__dirname, ".env");
 const envFileContent = fs.readFileSync(envFilePath, "utf8");
 const updatedEnvFileContent = `${envFileContent}\nBOT_DATA=${JSON.stringify(
-  botData
+  { ...botData, meetingInfo: defineMeetingInfo(url) }
 )}`;
 fs.writeFileSync(envFilePath, updatedEnvFileContent);
 
+// Log "success"
 console.log("BOT_DATA variable appended to .env file");


### PR DESCRIPTION
### TL;DR

Completes MEE-203

Simplified the bot configuration process by automatically parsing meeting URLs instead of requiring manual entry of meeting details.

### What changed?

- Added URL parsing functionality to automatically extract meeting details from a meeting URL
- Simplified the `botData` configuration by removing the need to manually specify meeting parameters
- Added support for parsing different meeting platform URLs (Google Meet, Zoom, Teams)
- Implemented validation functions to check if a URL is valid for each platform
- Added helper functions to extract specific meeting parameters from URLs
- Updated the environment variable generation to use the parsed meeting information

### How to test?

1. Paste your meeting URL in the `url` variable at the top of the file
2. Run the script to generate the environment variables
3. Verify that the correct meeting parameters are extracted based on the URL format:
   - Google Meet: `meet.google.com/xxx-xxxx-xxx`
   - Zoom: `zoom.us/j/123456789?pwd=xxxxx`
   - Teams: Teams meeting URL with meeting ID, tenant ID, and organizer ID

### Why make this change?

This change simplifies the bot configuration process by requiring only a meeting URL instead of manually entering multiple meeting parameters. It reduces the chance of errors when setting up bots and makes the onboarding process more user-friendly by automatically detecting the meeting platform and extracting the necessary information.