### PR TITLE
feat:meet-bot-exit-test-cases

### DIFF
--- a/src/bots/src/bot.ts
+++ b/src/bots/src/bot.ts
@@ -8,6 +8,11 @@ export interface BotInterface {
   getContentType(): string;
   run(): Promise<void>;
   screenshot(fName?: string): Promise<void>;
+
+  //
+  joinMeeting(): Promise<any>;
+  endLife(): Promise<any>;
+  checkKicked(): Promise<boolean>;
 }
 
 export class Bot implements BotInterface {
@@ -72,6 +77,14 @@ export class Bot implements BotInterface {
    * @returns {string} contentType
    */
   getContentType(): string {
+    throw new Error("Method not implemented.");
+  }
+
+  /**
+   * Check if the bot has been kicked from the meeting.
+   * @returns {Promise<boolean>} - True if the bot has been kicked, false otherwise.
+   */
+  async checkKicked(): Promise<boolean> {
     throw new Error("Method not implemented.");
   }
 }

--- a/src/bots/teams/src/bot.ts
+++ b/src/bots/teams/src/bot.ts
@@ -145,6 +145,14 @@ export class TeamsBot extends Bot {
     console.log("Successfully joined meeting");
   }
 
+
+  // Ensure we're not kicked from the meeting
+  async checkKicked() {
+    // TOOD: Implement this
+    return false;
+  }
+
+
   async run() {
 
     // Start Join

--- a/src/bots/tests/bot_exit.test.ts
+++ b/src/bots/tests/bot_exit.test.ts
@@ -1,0 +1,156 @@
+import { MeetsBot } from "../meet/src/bot";
+import * as dotenv from 'dotenv';
+import { BotConfig } from "../src/types";
+import { TeamsBot } from "../teams/src/bot";
+import { ZoomBot } from "../zoom/src/bot";
+import { jest } from '@jest/globals';
+import exp from "constants";
+
+
+jest.mock('superjson', () => ({
+    serialize: jest.fn((data) => ({ json: JSON.stringify(data), meta: null })),
+    deserialize: jest.fn((data: any) => JSON.parse(data.json)),
+}));
+
+
+// Create Mock Configs
+dotenv.config();
+const mockMeetConfig = {
+    id: 0,
+    meetingInfo: JSON.parse(process.env.MEET_TEST_MEETING_INFO || '{}'),
+    automaticLeave: {
+        // automaticLeave: null, //Not included to see what happens on a bad config
+    }
+} as BotConfig;
+
+describe('Meet Bot Exit Tests', () => {
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    /**
+     * Create a meet and join a predefined meeting (set in MEET_MEETING_INFO, above. When testing, you need to make sure this a valid meeting link).
+     * This lets you check if the bot can join a meeting and if it can handle the waiting room -- good to know if the UI changed
+    */
+
+    it('Meet : Detect Empty Participation and Exit the meeting', async () => {
+        
+        // Create Bot
+        const bot = new MeetsBot(mockMeetConfig, async (eventType: string, data: any) => { });
+
+        // Mock bot.joinMeeting to simulate the page setup and override waitForSelector
+        bot.page = {
+            waitForSelector: jest.fn(async () => {return 0;}), // Simulate successful navigation
+            click: jest.fn(async () => {return 0;}), // Simulate successful navigation
+            exposeFunction: jest.fn(async () => {return 0;}), // Simulate successful function loading
+            evaluate: jest.fn(async () => {return 0;}), // Simulate successful evaluation
+        } as any; // Mock the page object
+
+
+        // replace the bot.checkKicked function with a mock implementation
+        // i.e we NEVER got kicked
+        jest.spyOn(bot, "checkKicked").mockImplementation(async () => {
+            return false;
+        });
+
+        // Mock Bot Recording -- don't actually want to
+        jest.spyOn(bot, "startRecording").mockImplementation(async () => {
+            console.log("Mock startRecording called");
+        });
+        jest.spyOn(bot, "stopRecording").mockImplementation(async () => {
+            console.log("Mock stopRecording called");
+            return 0;
+        });
+
+        // Ensure bot would have ended it's life
+        jest.spyOn(bot, "endLife").mockImplementation(async () => {
+            console.log("Mock endLife called");
+        });
+
+        // Run Meeting info without setting up the browser
+
+        // Break private value setter and set the timeAloneStarted to a value that is a long time ago
+        (bot as any).timeAloneStarted = Date.now() - 1000000;
+        (bot as any).participantCount = 1; //simulate it being only me in the meeting
+        await bot.meetingActions();
+
+        expect(bot.endLife).toHaveBeenCalled();
+
+    }, 60000); // Set max timeout to 60 seconds
+
+    it('Meet : Ensure on Bot Kicked proper events', async () => {
+        
+        // Create Bot
+        const bot = new MeetsBot(mockMeetConfig, async (eventType: string, data: any) => { });
+
+        // Mock bot.joinMeeting to simulate the page setup and override waitForSelector
+        bot.page = {
+            waitForSelector: jest.fn(async () => {return 0;}), // Simulate successful navigation
+            click: jest.fn(async () => {return 0;}), // Simulate successful navigation
+            exposeFunction: jest.fn(async () => {return 0;}), // Simulate successful function loading
+            evaluate: jest.fn(async () => {return 0;}), // Simulate successful evaluation
+        } as any; // Mock the page object
+
+
+        // replace the bot.checkKicked function with a mock implementation
+        // i.e Ensure bot
+        jest.spyOn(bot, "checkKicked").mockImplementation(async () => {
+            return true;
+        });
+
+        // Mock Bot Recording -- don't actually want to
+        jest.spyOn(bot, "startRecording").mockImplementation(async () => {
+            console.log("Mock startRecording called");
+        });
+        jest.spyOn(bot, "stopRecording").mockImplementation(async () => {
+            console.log("Mock stopRecording called");
+            return 0;
+        });
+
+        // Ensure bot would have ended it's life
+        jest.spyOn(bot, "endLife").mockImplementation(async () => {
+            console.log("Mock endLife called");
+        });
+
+        // Run Meeting info without setting up the browser
+
+        // Break private value setter and set the timeAloneStarted to a value that is a long time ago
+        (bot as any).timeAloneStarted = Date.now() - 1000000;
+        (bot as any).participantCount = 5; //simulate there being a lot of people in the meeting
+        await bot.meetingActions();
+
+        // Ensure endLife would have been called
+        expect(bot.endLife).toHaveBeenCalled();
+
+    }, 60000); // Set max timeout to 60 seconds
+
+
+    it('Meet : Ensure can leave meeting if UI does not allow for it', async () => {
+
+        // Create Bot
+        const bot = new MeetsBot(mockMeetConfig, async (eventType: string, data: any) => { });
+
+        // Mock bot.joinMeeting to simulate the page setup and override waitForSelector
+        bot.page = {
+            waitForSelector: jest.fn(async () => {return 0;}), // Simulate successful navigation
+            click: jest.fn(async () => {return 0;}), // Simulate successful navigation
+            exposeFunction: jest.fn(async () => {return 0;}), // Simulate successful function loading
+            evaluate: jest.fn(async () => {return 0;}), // Simulate successful evaluation
+        } as any; // Mock the page object
+
+        //Test Function
+        bot.leaveMeeting();
+
+        // Ensure bot would have ended it's life
+        jest.spyOn(bot, "endLife").mockImplementation(async () => {
+            console.log("Mock endLife called");
+        });
+
+        // Ensure end meeting calls endLife (closes browser) even if an irregular leaveMeeting event.
+        expect(bot.endLife).toHaveBeenCalled();
+
+    }, 6000);
+
+
+});

--- a/src/bots/zoom/src/bot.ts
+++ b/src/bots/zoom/src/bot.ts
@@ -44,6 +44,12 @@ export class ZoomBot extends Bot {
     console.log(`Screenshot saved to ${screenshotPath}`);
   }
 
+  async checkKicked(): Promise<boolean> {
+
+    //TODO: Implement this
+    return false;
+  }
+
 
   /**
    * Opens a browser and navigatges, joins the meeting.


### PR DESCRIPTION

## Notice
I have implemented these tests only for the meets bot as it is currently the only bot to check for it's kicked status. My next PR will be the other two bots catching up with this functionality.

### TL;DR

Refactored meeting exit detection logic and added tests for bot exit scenarios. 

### What changed?

- Created a new `checkKicked()` method in the `MeetsBot` class to consolidate kick detection logic
- Added the `checkKicked()` method to the `BotInterface` and implemented stubs in `TeamsBot` and `ZoomBot`
- Added default timeout value for automatic leave when everyone has left the meeting
- Created comprehensive tests for bot exit scenarios in `bot_exit.test.ts`:
  - Testing detection of empty participation
  - Testing proper handling when bot is kicked
  - Testing meeting exit when UI doesn't allow normal leaving

### How to test?

Run the new test suite:
```
npm test -- bot_exit.test.ts
```

The tests verify:
1. Bot exits when it's the only participant left
2. Bot properly handles being kicked from a meeting
3. Bot can exit a meeting even when UI doesn't provide normal exit options

### Why make this change?

This refactoring improves code maintainability by:
1. Centralizing the kick detection logic into a single method
2. Standardizing the bot interface across different meeting platforms
3. Adding proper error handling for edge cases like missing configuration
4. Adding tests to ensure reliable exit behavior across different scenarios

The changes make the bot more robust when dealing with unexpected meeting terminations and ensure consistent behavior across different meeting platforms.