### PR TITLE
fix: additional bot exit handling tests

### DIFF
--- a/src/bots/meet/src/bot.ts
+++ b/src/bots/meet/src/bot.ts
@@ -390,7 +390,7 @@ export class MeetsBot extends Bot {
     });
 
     // Save the screenshot to a file
-    const screenshotPath = `./${fName}`;
+    const screenshotPath = path.resolve(`/tmp/${fName}`);
     fs.writeFileSync(screenshotPath, screenshot);
     console.log(`Screenshot saved to ${screenshotPath}`);
   }
@@ -580,8 +580,14 @@ export class MeetsBot extends Bot {
     //
     // Exit
     console.log("Starting End Life Actions ...");
-    await this.leaveMeeting();
-    return 0;
+
+    try {
+      await this.leaveMeeting();
+      return 0;
+    } catch (e) {
+      this.endLife();
+      return 1;
+    }
   }
 
   /** 
@@ -611,14 +617,15 @@ export class MeetsBot extends Bot {
   async leaveMeeting() {
 
     // Try and Find the leave button, press. Otherwise, just delete the browser.
+    console.log("Trying to leave the call ...")
     try {
-      console.log("Trying to leave the call ...")
       await this.page.click(leaveButton, { timeout: 1000 }); //Short Attempt
-      console.log('Left Call.')
+      console.log('Left Call.');
     } catch (e) {
       console.log('Attempted to Leave Call - couldn\'t (probably aleready left).')
     }
 
+    console.log('Ending Life ...');
     this.endLife();
     return 0;
   }

--- a/src/bots/teams/src/bot.ts
+++ b/src/bots/teams/src/bot.ts
@@ -4,6 +4,7 @@ import { launch, getStream, wss } from "puppeteer-stream";
 import crypto from "crypto";
 import { BotConfig, EventCode, WaitingRoomTimeoutError } from "../../src/types";
 import { Bot } from "../../src/bot";
+import path from "path";
 
 const leaveButtonSelector =
   'button[aria-label="Leave (Ctrl+Shift+H)"], button[aria-label="Leave (⌘+Shift+H)"]';
@@ -49,7 +50,7 @@ export class TeamsBot extends Bot {
       });
 
       // Save the screenshot to a file
-      const screenshotPath = `./${fName}`;
+      const screenshotPath = path.resolve(`/tmp/${fName}`);
       fs.writeFileSync(screenshotPath, screenshot);
       console.log(`Screenshot saved to ${screenshotPath}`);
     } catch (error) {

--- a/src/bots/tests/bot_exit.test.ts
+++ b/src/bots/tests/bot_exit.test.ts
@@ -3,15 +3,13 @@ import * as dotenv from 'dotenv';
 import { BotConfig } from "../src/types";
 import { TeamsBot } from "../teams/src/bot";
 import { ZoomBot } from "../zoom/src/bot";
-import { jest } from '@jest/globals';
+import { beforeAll, beforeEach, jest } from '@jest/globals';
 import exp from "constants";
-
 
 jest.mock('superjson', () => ({
     serialize: jest.fn((data) => ({ json: JSON.stringify(data), meta: null })),
     deserialize: jest.fn((data: any) => JSON.parse(data.json)),
 }));
-
 
 // Create Mock Configs
 dotenv.config();
@@ -22,39 +20,40 @@ const mockMeetConfig = {
         // automaticLeave: null, //Not included to see what happens on a bad config
     }
 } as BotConfig;
+const mockZoomConfig = {
+    id: 0,
+    meetingInfo: JSON.parse(process.env.ZOOM_TEST_MEETING_INFO || '{}'),
+    automaticLeave: {
+        // automaticLeave: null, //Not included to see what happens on a bad config
+    }
+} as BotConfig;
+const mockTeamsConfig = {
+    id: 0,
+    meetingInfo: JSON.parse(process.env.TEAMS_TEST_MEETING_INFO || '{}'),
+    automaticLeave: {
+        // automaticLeave: null, //Not included to see what happens on a bad config
+    }
+} as BotConfig;
 
 describe('Meet Bot Exit Tests', () => {
 
-    afterEach(() => {
-        jest.clearAllMocks();
-    });
+    let bot: MeetsBot;
 
-    /**
-     * Create a meet and join a predefined meeting (set in MEET_MEETING_INFO, above. When testing, you need to make sure this a valid meeting link).
-     * This lets you check if the bot can join a meeting and if it can handle the waiting room -- good to know if the UI changed
-    */
+    // Create the bot for each
+    beforeEach(() => {
 
-    it('Meet : Detect Empty Participation and Exit the meeting', async () => {
-        
         // Create Bot
-        const bot = new MeetsBot(mockMeetConfig, async (eventType: string, data: any) => { });
+        bot = new MeetsBot(mockMeetConfig, async (eventType: string, data: any) => { });
 
-        // Mock bot.joinMeeting to simulate the page setup and override waitForSelector
+        // Override Page functionality (ignore navigation)
         bot.page = {
-            waitForSelector: jest.fn(async () => {return 0;}), // Simulate successful navigation
-            click: jest.fn(async () => {return 0;}), // Simulate successful navigation
-            exposeFunction: jest.fn(async () => {return 0;}), // Simulate successful function loading
-            evaluate: jest.fn(async () => {return 0;}), // Simulate successful evaluation
+            waitForSelector: jest.fn(async () => { return 0; }), // Simulate successful navigation
+            click: jest.fn(async () => { return 0; }), // Simulate successful navigation
+            exposeFunction: jest.fn(async () => { return 0; }), // Simulate successful function loading
+            evaluate: jest.fn(async () => { return 0; }), // Simulate successful evaluation
         } as any; // Mock the page object
 
-
-        // replace the bot.checkKicked function with a mock implementation
-        // i.e we NEVER got kicked
-        jest.spyOn(bot, "checkKicked").mockImplementation(async () => {
-            return false;
-        });
-
-        // Mock Bot Recording -- don't actually want to
+        // Mock Bot Recording -- never actually record
         jest.spyOn(bot, "startRecording").mockImplementation(async () => {
             console.log("Mock startRecording called");
         });
@@ -66,6 +65,24 @@ describe('Meet Bot Exit Tests', () => {
         // Ensure bot would have ended it's life
         jest.spyOn(bot, "endLife").mockImplementation(async () => {
             console.log("Mock endLife called");
+        });
+    })
+
+    // Cleanup
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    /**
+     * Create a meet and join a predefined meeting (set in MEET_MEETING_INFO, above. When testing, you need to make sure this a valid meeting link).
+     * This lets you check if the bot can join a meeting and if it can handle the waiting room -- good to know if the UI changed
+    */
+    it('Detect Empty Participation and Exit the meeting', async () => {
+
+        // replace the bot.checkKicked function with a mock implementation
+        // Here: We did not got kicked
+        jest.spyOn(bot, "checkKicked").mockImplementation(async () => {
+            return false;
         });
 
         // Run Meeting info without setting up the browser
@@ -75,42 +92,16 @@ describe('Meet Bot Exit Tests', () => {
         (bot as any).participantCount = 1; //simulate it being only me in the meeting
         await bot.meetingActions();
 
-        expect(bot.endLife).toHaveBeenCalled();
+        expect(bot.endLife).toHaveBeenCalled(); //includes stopRecording()
 
     }, 60000); // Set max timeout to 60 seconds
 
-    it('Meet : Ensure on Bot Kicked proper events', async () => {
-        
-        // Create Bot
-        const bot = new MeetsBot(mockMeetConfig, async (eventType: string, data: any) => { });
-
-        // Mock bot.joinMeeting to simulate the page setup and override waitForSelector
-        bot.page = {
-            waitForSelector: jest.fn(async () => {return 0;}), // Simulate successful navigation
-            click: jest.fn(async () => {return 0;}), // Simulate successful navigation
-            exposeFunction: jest.fn(async () => {return 0;}), // Simulate successful function loading
-            evaluate: jest.fn(async () => {return 0;}), // Simulate successful evaluation
-        } as any; // Mock the page object
-
+    it('Ensure on Bot Kicked proper events', async () => {
 
         // replace the bot.checkKicked function with a mock implementation
-        // i.e Ensure bot
+        // i.e Ensure bot is always kicked right away 
         jest.spyOn(bot, "checkKicked").mockImplementation(async () => {
             return true;
-        });
-
-        // Mock Bot Recording -- don't actually want to
-        jest.spyOn(bot, "startRecording").mockImplementation(async () => {
-            console.log("Mock startRecording called");
-        });
-        jest.spyOn(bot, "stopRecording").mockImplementation(async () => {
-            console.log("Mock stopRecording called");
-            return 0;
-        });
-
-        // Ensure bot would have ended it's life
-        jest.spyOn(bot, "endLife").mockImplementation(async () => {
-            console.log("Mock endLife called");
         });
 
         // Run Meeting info without setting up the browser
@@ -121,36 +112,201 @@ describe('Meet Bot Exit Tests', () => {
         await bot.meetingActions();
 
         // Ensure endLife would have been called
-        expect(bot.endLife).toHaveBeenCalled();
+        expect(bot.endLife).toHaveBeenCalled();  //includes stopRecording()
 
     }, 60000); // Set max timeout to 60 seconds
 
 
-    it('Meet : Ensure can leave meeting if UI does not allow for it', async () => {
+    it('Ensure can leave meeting if UI does not allow for it', async () => {
 
-        // Create Bot
-        const bot = new MeetsBot(mockMeetConfig, async (eventType: string, data: any) => { });
+        // Kick Self
+        jest.spyOn(bot, "checkKicked").mockImplementation(async () => {
+            return true;
+        });
 
-        // Mock bot.joinMeeting to simulate the page setup and override waitForSelector
-        bot.page = {
-            waitForSelector: jest.fn(async () => {return 0;}), // Simulate successful navigation
-            click: jest.fn(async () => {return 0;}), // Simulate successful navigation
-            exposeFunction: jest.fn(async () => {return 0;}), // Simulate successful function loading
-            evaluate: jest.fn(async () => {return 0;}), // Simulate successful evaluation
-        } as any; // Mock the page object
+        // Error on Leave Meeting (cannot click the button somehow)
+        jest.spyOn(bot, "leaveMeeting").mockImplementation(async () => {
+            console.log("Mock leaveMeeting called");
+            throw new Error("Unable to leave meeting"); // Simulate an error when trying to leave the meeting
+        });
 
         //Test Function
-        bot.leaveMeeting();
+        await bot.meetingActions();
+
+        // Ensure end meeting calls endLife (closes browser) even if an irregular leaveMeeting event.
+        expect(bot.endLife).toHaveBeenCalled();  //includes stopRecording()
+
+    }, 6000);
+
+
+});
+
+// ===========================================================================
+// ===========================================================================
+// ===========================================================================
+// ===========================================================================
+
+describe('Zoom Bot Exit Tests', () => {
+
+    let bot: ZoomBot;
+
+    beforeEach(() => {
+
+        // Mock WebSocket connection for Puppeteer
+        jest.mock('puppeteer', () => {
+            const originalModule: any = jest.requireActual('puppeteer');
+            return {
+                ...originalModule,
+                wss: jest.fn(async () => ({
+                    wsEndpoint: jest.fn(() => 'ws://mocked-websocket-endpoint'),
+                    disconnect: jest.fn(),
+                })),
+            };
+        });
+
+
+        // Create Bot
+        bot = new ZoomBot(mockZoomConfig, async (eventType: string, data: any) => { });
+
+        // mock items
+        bot.page = {
+            waitForSelector: jest.fn(async () => { return 0; }), // Simulate successful navigation
+            click: jest.fn(async () => { return 0; }), // Simulate successful navigation
+            exposeFunction: jest.fn(async () => { return 0; }), // Simulate successful function loading
+            evaluate: jest.fn(async () => { return 0; }), // Simulate successful evaluation
+        } as any; // Mock the page object
+
+        bot.browser = {} as any;
 
         // Ensure bot would have ended it's life
         jest.spyOn(bot, "endLife").mockImplementation(async () => {
             console.log("Mock endLife called");
         });
 
-        // Ensure end meeting calls endLife (closes browser) even if an irregular leaveMeeting event.
-        expect(bot.endLife).toHaveBeenCalled();
+        jest.spyOn(bot, "startRecording").mockImplementation(async () => {
+            console.log("Mock startRecording called");
+        });
 
+        jest.spyOn(bot, "stopRecording").mockImplementation(async () => {
+            console.log("Mock stopRecording called");
+        });
+
+        jest.spyOn(bot, "joinMeeting").mockImplementation(async () => {
+            console.log("Mock joinMeeting called");
+        });
+
+    });
+
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    /**
+     * Create a meet and join a predefined meeting (set in MEET_MEETING_INFO, above. When testing, you need to make sure this a valid meeting link).
+     * This lets you check if the bot can join a meeting and if it can handle the waiting room -- good to know if the UI changed
+    */
+
+    it.skip('Detect Empty Participation and Exit the meeting', async () => {
+        // Empty Test -- no implementation yet
+        expect(false).toBe(true);
+    });
+
+    it.skip('Ensure on Bot Kicked proper events', async () => {
+        // Empty Test -- no implementation yet
+        expect(false).toBe(true);
+    });
+
+
+    it.skip('Ensure can leave meeting if UI does not allow for it', async () => {
+        // Empty Test -- no implementation yet
+        expect(false).toBe(true);
+    });
+});
+
+// ===========================================================================
+// ===========================================================================
+// ===========================================================================
+// ===========================================================================
+
+describe('Teams Bot Exit Tests', () => {
+
+    let bot: TeamsBot;
+
+    beforeEach(() => {
+
+        // Mock WebSocket connection for Puppeteer
+        jest.mock('puppeteer', () => {
+            const originalModule: any = jest.requireActual('puppeteer');
+            return {
+                ...originalModule,
+                wss: jest.fn(async () => ({
+                    wsEndpoint: jest.fn(() => 'ws://mocked-websocket-endpoint'),
+                    disconnect: jest.fn(),
+                })),
+            };
+        });
+
+        // Create Bot
+        bot = new TeamsBot(mockTeamsConfig, async (eventType: string, data: any) => { });
+
+        // mock items
+        bot.page = {
+            waitForSelector: jest.fn(async () => { return 0; }), // Simulate successful navigation
+            click: jest.fn(async () => { return 0; }), // Simulate successful navigation
+            exposeFunction: jest.fn(async () => { return 0; }), // Simulate successful function loading
+            evaluate: jest.fn(async () => { return 0; }), // Simulate successful evaluation
+        } as any; // Mock the page object
+
+        // Override
+        bot.browser = {} as any;
+
+        // Add mock to ensure bot would have ended it's life
+        jest.spyOn(bot, "endLife").mockImplementation(async () => {
+            console.log("Mock endLife called");
+        });
+    });
+
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    /**
+     * Create a meet and join a predefined meeting (set in MEET_MEETING_INFO, above. When testing, you need to make sure this a valid meeting link).
+     * This lets you check if the bot can join a meeting and if it can handle the waiting room -- good to know if the UI changed
+    */
+
+    it.skip('Detect Empty Participation and Exit the meeting', async () => {
+
+        // Ensure bot would have ended it's life
+        jest.spyOn(bot, "joinMeeting").mockImplementation(async () => {
+            console.log("Mock joinMeeting called");
+        });
+
+        // Empty Test -- no implementation yet
+        expect(false).toBe(true);
+    });
+
+    it.skip('Ensure on Bot Kicked proper events', async () => {
+
+        // 
+        jest.spyOn(bot, "joinMeeting").mockImplementation(async () => {
+            console.log("Mock joinMeeting called");
+        });
+
+        // Empty Test -- no implementation yet
+        expect(false).toBe(true);
+    });
+
+
+    it.skip('Ensure can leave meeting if UI does not allow for it', async () => {
+
+        jest.spyOn(bot, "joinMeeting").mockImplementation(async () => {
+            console.log("Mock joinMeeting called");
+        });
+
+        // Empty Test -- no implementation yet
+        expect(false).toBe(true);
     }, 6000);
-
-
 });

--- a/src/bots/zoom/src/bot.ts
+++ b/src/bots/zoom/src/bot.ts
@@ -5,12 +5,15 @@ import { BotConfig, EventCode, WaitingRoomTimeoutError } from "../../src/types";
 import { Bot } from "../../src/bot";
 import path from "path";
 
+
+
 // Constant Selectors
 const muteButton = 'button[aria-label="Mute"]';
 const stopVideoButton = 'button[aria-label="Stop Video"]';
 const joinButton = 'button.zm-btn.preview-join-button';
 const leaveButton = 'button[aria-label="Leave"]';
 import { Browser } from "puppeteer";
+import { Transform } from "stream";
 
 export class ZoomBot extends Bot {
   recordingPath: string;
@@ -19,6 +22,7 @@ export class ZoomBot extends Bot {
   browser!: Browser;
   page!: Page;
   file!: fs.WriteStream;
+  stream!: Transform;
 
   constructor(
     botSettings: BotConfig,
@@ -32,14 +36,16 @@ export class ZoomBot extends Bot {
 
 
   async screenshot(fName: string = "screenshot.png") {
+    if (!this.browser) throw new Error("Browser not initialized");
     if (!this.page) throw new Error("Page not initialized");
+
     const screenshot = await this.page.screenshot({
       type: "png",
       encoding: "binary",
     });
 
     // Save the screenshot to a file
-    const screenshotPath = `./${fName}`;
+    const screenshotPath = path.resolve(`/tmp/${fName}`);
     fs.writeFileSync(screenshotPath, screenshot);
     console.log(`Screenshot saved to ${screenshotPath}`);
   }
@@ -139,6 +145,34 @@ export class ZoomBot extends Bot {
     }
   }
 
+  /**
+   * Start Recording the meeting.
+   */
+  async startRecording() {
+    // Check if the page is initialized
+    if (!this.page) throw new Error("Page not initialized");
+
+    // Create the Stream
+    this.stream = await getStream(this.page as any, { audio: true, video: true });
+  
+    // Create and Write the recording to a file, pipe the stream to a fileWriteStream
+    this.file = fs.createWriteStream(this.recordingPath);
+    this.stream.pipe(this.file);
+
+  }
+
+  /**
+   * Stop Recording the meeting.
+   */
+  async stopRecording() {
+
+      // End the recording and close the file
+      if (this.stream)
+        this.stream.destroy();
+
+  }
+
+
   async run() {
 
     // Navigate and join the meeting.
@@ -152,11 +186,7 @@ export class ZoomBot extends Bot {
       throw new Error("Page is not initialized");
 
     // Start the recording -- again, type issue from importing.
-    const stream = await getStream(this.page as any, { audio: true, video: true });
-
-    // Create and Write the recording to a file, pipe the stream to a fileWriteStream
-    this.file = fs.createWriteStream(this.recordingPath);
-    stream.pipe(this.file);
+    const stream = await this.startRecording();
 
     console.log("Recording...");
 
@@ -185,8 +215,8 @@ export class ZoomBot extends Bot {
         // Click the button to leave the meeting
         await okButton.click();
 
-        // End the recording and close the file
-        stream.destroy();
+        // Stop Recording
+        this.stopRecording();
 
         // End Life -- Close file, browser, and websocket server
         this.endLife();
@@ -215,6 +245,9 @@ export class ZoomBot extends Bot {
    * Ensure the filestream is closed as well.
    */
   async endLife() {
+
+    // Ensure Recording is stopped in unideal situations
+    this.stopRecording();
 
     // Close File if it exists
     if (this.file) {


### PR DESCRIPTION
### TL;DR

Improved error handling for meeting bots to ensure proper cleanup when exiting meetings.

### What changed?

- Expanded test coverage for bot exit scenarios with comprehensive test cases for all bot types. Currently Zoom/Teams do not have this functionality, so these tests are skipped.
- Enhanced `MeetsBot.meetingActions()` with try/catch to handle errors during `leaveMeeting()`
- Added logging to `leaveMeeting()` for better debugging
- Implemented `startRecording()` and `stopRecording()` methods in `ZoomBot`
- Added proper cleanup in `ZoomBot.endLife()` to ensure recording is stopped
- Moved the debug screenshot location to `/tmp/`


### How to test?

1. Run the bot exit tests with `pnpm exec jest bot_exit.test.ts`
2. Verify that bots properly clean up resources when exiting meetings
3. Test error scenarios by forcing failures during the meeting exit process

### Why make this change?

This change improves the reliability of meeting bots by ensuring proper cleanup of resources (browser, recordings, etc.) even when errors occur during the meeting exit process. The enhanced error handling prevents resource leaks and ensures consistent behavior across different meeting platforms.