### PR TITLE
fix: turn-off-heartbeat-flooding-if-required

### DIFF
--- a/src/bots/.env.example
+++ b/src/bots/.env.example
@@ -4,5 +4,8 @@ AWS_SECRET_ACCESS_KEY=your_secret_access_key
 AWS_BUCKET_NAME=your_bucket_name
 AWS_REGION=your_region
 
+# Usefull for debugging. If you set to =false, then any failure in the heartbeat ping will not be logged.
+HEARTBEAT_DEBUG=true
+
 # Bot data (example - this will be set by the backend)
 BOT_DATA={"botId":1,"meetingUrl":"https://meet.google.com/xxx-xxxx-xxx","botName":"Meeting Bot","recordingPath":"./recording.mp4","automaticLeave":{"waitingRoomTimeout":300000,"noOneJoinedTimeout":300000,"everyoneLeftTimeout":300000}}

--- a/src/bots/src/monitoring.ts
+++ b/src/bots/src/monitoring.ts
@@ -12,7 +12,10 @@ export const startHeartbeat = async (
       await trpc.bots.heartbeat.mutate({ id: botId });
       console.log(`[${new Date().toISOString()}] Heartbeat sent`);
     } catch (error) {
-      console.error("Failed to send heartbeat:", error);
+
+      // Do not log the entire heartbeat error if, in local, the user has set HEARTBEAT_DEBUG to false.
+      if ((process.env?.HEARTBEAT_DEBUG ?? 'true') !== 'false')
+        console.error("Failed to send heartbeat:", error);
     }
     await setTimeout(5000); // Send heartbeat every 5 seconds
   }


### PR DESCRIPTION
### TL;DR

Added a HEARTBEAT_DEBUG environment variable to control heartbeat error logging -- stops flooding the terminal with 'heartbeat could not send' error if the backend is not online.

### What changed?

- Added a new `HEARTBEAT_DEBUG` environment variable in `.env.example` with a default value of `true`
- Modified the heartbeat error handling in `monitoring.ts` to only log errors when `HEARTBEAT_DEBUG` is not explicitly set to `false`
- Added a comment explaining the purpose of the new environment variable

### How to test?

1. Copy the new `HEARTBEAT_DEBUG` variable to your `.env` file
2. Set `HEARTBEAT_DEBUG=false` to suppress heartbeat error logs
3. Set `HEARTBEAT_DEBUG=true` or leave it unset to see heartbeat error logs
4. Trigger a heartbeat error (e.g., by disconnecting from the network) to verify the logging behavior

### Why make this change?

This change allows developers to suppress heartbeat error logs during local development, which can be noisy and distracting when working in an environment where heartbeat failures are expected or irrelevant. The default behavior remains unchanged (errors are logged), but developers now have the option to disable this logging when needed.