### PR TITLE
feat:recording-tests

### DIFF
--- a/src/bots/__mocks__/@aws-sdk/client-s3.ts
+++ b/src/bots/__mocks__/@aws-sdk/client-s3.ts
@@ -1,3 +1,12 @@
-const S3Client = jest.fn(() => {console.log('S3Client called')});
+const S3Client = jest.fn(function (params) {
+	console.log('S3Client called with params:', params);
+	this.send = jest.fn((params) => {
+        console.log('S3Client send called with params:', params);
+    }); // Mock the send method
+    this.destroy = jest.fn(); // Mock the destroy method
+});
+const PutObjectCommand = jest.fn(function (params) {
+	console.log('PutObjectCommand called with params:', params);
+});
 
-export { S3Client };
+export { S3Client, PutObjectCommand };

--- a/src/bots/__mocks__/fs.ts
+++ b/src/bots/__mocks__/fs.ts
@@ -1,0 +1,17 @@
+// Log reading in a file -- pass back empty file content
+const readFileSync = jest.fn((path: string) => {
+    console.log('Mocking Reading In a file:', path);
+    return Buffer.from('some-file-content');
+});
+
+// Mock Async promises
+const promises = {
+
+    // Override the unlink method to log the path being unlinked
+    unlink: jest.fn(async (path: string) => {
+        console.log('Mocking Unlinking a file:', path);
+        return Promise.resolve();
+    }),
+};
+
+export { readFileSync, promises };

--- a/src/bots/__mocks__/puppeteer-stream.ts
+++ b/src/bots/__mocks__/puppeteer-stream.ts
@@ -1,28 +1,33 @@
 // Mock Puppeteer-stream (called in ../zoom/src/bot.ts)
-const puppeteerStreamMock = {
-    launch: jest.fn(() => ({
-        defaultBrowserContext: jest.fn(() => ({
-            clearPermissionOverrides: jest.fn(),
-            overridePermissions: jest.fn(),
-        })),
-        newPage: jest.fn(() => ({
-            goto: jest.fn(),
-            waitForSelector: jest.fn(() => ({
-                contentFrame: jest.fn(() => ({
-                    waitForSelector: jest.fn(),
-                    click: jest.fn(),
-                    type: jest.fn(),
-                })),
+const launch = jest.fn(() => {
+    
+    console.log('Mocking Puppeteer Launch');
+
+    return {
+    defaultBrowserContext: jest.fn(() => ({
+        clearPermissionOverrides: jest.fn(),
+        overridePermissions: jest.fn(),
+    })),
+    newPage: jest.fn(() => ({
+        goto: jest.fn(),
+        waitForSelector: jest.fn(() => ({
+            contentFrame: jest.fn(() => ({
+                waitForSelector: jest.fn(),
+                click: jest.fn(),
+                type: jest.fn(),
             })),
         })),
     })),
-    getStream: jest.fn(() => ({
-        pipe: jest.fn(),
-        destroy: jest.fn(),
-    })),
-    wss: jest.fn(() => ({
-        close: jest.fn(),
-    })),
-};
+    close: jest.fn(),
+}});
 
-export default puppeteerStreamMock;
+const getStream = jest.fn(() => ({
+    pipe: jest.fn(),
+    destroy: jest.fn(),
+}));
+
+const wss = jest.fn(() => Promise.resolve({
+    close: jest.fn(),
+}));
+
+export { getStream, launch, wss };

--- a/src/bots/src/types.ts
+++ b/src/bots/src/types.ts
@@ -60,3 +60,10 @@ export class WaitingRoomTimeoutError extends Error {
     this.name = "WaitingRoomTimeoutError";
   }
 }
+//
+export class MeetingJoinError extends Error {
+  constructor(message: string = "Simulated Meeting Join Error") {
+    super(message);
+    this.name = "MeetingJoinError";
+  }
+}

--- a/src/bots/tests/bot.test.ts
+++ b/src/bots/tests/bot.test.ts
@@ -4,6 +4,12 @@ import { BotConfig } from "../src/types";
 import { ZoomBot } from "../zoom/src/bot";
 import { TeamsBot } from "../teams/src/bot";
 
+
+// 
+// Bot Creation Tests as described in Section 2.1.2.1
+// Of our System Verification and Validation Document.
+// 
+
 describe('Bot Creation from given data', () => {
 
     /**

--- a/src/bots/tests/bot_exit.test.ts
+++ b/src/bots/tests/bot_exit.test.ts
@@ -6,10 +6,12 @@ import { ZoomBot } from "../zoom/src/bot";
 import { beforeAll, beforeEach, jest } from '@jest/globals';
 import exp from "constants";
 
-jest.mock('superjson', () => ({
-    serialize: jest.fn((data) => ({ json: JSON.stringify(data), meta: null })),
-    deserialize: jest.fn((data: any) => JSON.parse(data.json)),
-}));
+
+// 
+// Bot Exiit Tests as described in Section 2.1.2.3
+// Of our System Verification and Validation Document.
+// 
+
 
 // Create Mock Configs
 dotenv.config();

--- a/src/bots/tests/meet_recording.test.ts
+++ b/src/bots/tests/meet_recording.test.ts
@@ -1,0 +1,128 @@
+import { MeetsBot } from "../meet/src/bot";
+import * as dotenv from 'dotenv';
+import { BotConfig } from "../src/types";
+import { TeamsBot } from "../teams/src/bot";
+import { ZoomBot } from "../zoom/src/bot";
+import { beforeAll, beforeEach, jest } from '@jest/globals';
+import exp from "constants";
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+// 
+// Bot Recording Tests as described in Section 2.1.2.4
+// Of our System Verification and Validation Document.
+// 
+
+//
+// Each of the Bot recording are in their seperate files because, for a reason I cannot find,
+//  the stream() is unavailable after the first test it is run. This doesn't impact the bot in production,
+// since we only ever send one .stream() request per bot.
+//
+
+
+// Create Mock Configs
+dotenv.config();
+const mockMeetConfig = {
+    id: 0,
+    meetingInfo: JSON.parse(process.env.MEET_TEST_MEETING_INFO || '{}'),
+    automaticLeave: {
+        // automaticLeave: null, //Not included to see what happens on a bad config
+    }
+} as BotConfig;
+
+describe('Meet Bot Record Tests', () => {
+
+    let bot: MeetsBot;
+    let recordingPath: null | string;
+
+    // Create the bot for each
+    beforeEach(() => {
+        // Create Bot
+        bot = new MeetsBot(mockMeetConfig, async (eventType: string, data: any) => { });
+        recordingPath = null;
+    });
+
+    // Cleanup
+    afterEach(() => {
+        jest.clearAllMocks();
+        if (recordingPath && fs.existsSync(recordingPath)) {
+            fs.unlinkSync(recordingPath);
+        }
+    });
+
+    /**
+     * Create a meet and join a predefined meeting (set in MEET_MEETING_INFO, above. When testing, you need to make sure this a valid meeting link).
+     * This lets you check if the bot can join a meeting and if it can handle the waiting room -- good to know if the UI changed
+    */
+    it.skip('Recording file Exists', async function () {
+
+        /**
+         *  Skipped because of ffmpeg requirments which aren't availabe locally wihtout tremendous effort. 
+         * 
+         * This necesatates that we run the tests in the docker container,
+         * but the way the test suite is setup and the other bots are structured
+         * (at the time of writing) makes it infeasable.
+         * 
+         * Ideally, you would run a command like
+         *      
+         *      "docker run --rm meet pnpm run test meet"
+         * 
+         * Which would run only meet specific test cases.
+         *
+         */
+
+        
+        // Check if ffmpeg is available
+        try {
+            execSync('ffmpeg -version', { stdio: 'ignore' });
+        } catch (error) {
+            console.warn('Skipping test: ffmpeg is not available.');
+            this.skip();
+            return;
+        }
+
+        // Launch a broser
+        await bot.launchBrowser();
+
+        // Mock page 
+        await bot.page.goto('https://www.google.com', { waitUntil: "networkidle" });
+        await bot.page.waitForTimeout(100);
+
+        // Start Recording
+        await bot.startRecording();
+        await bot.page.waitForTimeout(20000);
+
+        // Stop Recording
+        await bot.stopRecording();
+        await bot.page.waitForTimeout(1000);
+
+        // Stop Recording
+        const recordingPath = bot.getRecordingPath();
+
+        //End
+        await bot.endLife();
+
+        
+        // Assertions
+        expect(recordingPath).toBeDefined();
+        const fileExists = fs.existsSync(recordingPath);
+        expect(fileExists).toBe(true); // Ensure file exists
+
+        // Check dimensions using ffprobe
+        const ffprobeOutput = execSync(`ffprobe -v error -select_streams v:0 -show_entries stream=width,height -of json "${recordingPath}"`);
+        const dimensions = JSON.parse(ffprobeOutput);
+        
+        // Delete the temp file once we have read in dimensions
+        if (recordingPath && fs.existsSync(recordingPath)) {
+            fs.unlinkSync(recordingPath);
+        }
+        
+        // TODO: Use an input to determine the expected dimension, pass that to the bot when recording start.
+        // No implementation for that yet.
+        expect(dimensions.streams[0].width).toBeGreaterThan(0);
+        expect(dimensions.streams[0].height).toBeGreaterThan(0);
+
+
+    }, 60000); // Set max timeout to 60 seconds
+
+});

--- a/src/bots/tests/s3startup.test.ts
+++ b/src/bots/tests/s3startup.test.ts
@@ -1,6 +1,18 @@
-import { createS3Client } from '../src/s3';
+import { createS3Client, uploadRecordingToS3 } from '../src/s3';
+import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { S3Client } from '@aws-sdk/client-s3';
-import {describe, expect, test} from '@jest/globals';
+import {describe, expect, test, jest, it} from '@jest/globals';
+import fs from 'fs';
+import { BotConfig } from '../src/types';
+import { Bot } from '../src/bot';
+
+// 
+// Bot Startup Tests as described in Section 2.1.2, and recording upload tests as described in 2.1.2.4,
+// of our System Verification and Validation Document.
+// 
+
+// Excplicit mock build-in module required for jest to work with fs
+jest.mock('fs');
 
 describe('Bot S3 Startup Tests', () => {
 
@@ -38,5 +50,48 @@ describe('Bot S3 Startup Tests', () => {
         const result = createS3Client(undefined, undefined, undefined);
         expect(result).toBeNull();
     });
+});
 
+describe('S3Client Upload Tests', () => {
+
+    it("upload a file to S3", async () => {
+
+        // Fake S3 Client
+        const mockBucketName = "mock-bucket-name";
+        const mockKey = "mock-key";
+        const mockBody = "mock-body";
+
+        const s3Client = new S3Client({});
+        const putObjectCommand = new PutObjectCommand({
+            Bucket: mockBucketName,
+            Key: mockKey,
+            Body: mockBody,
+        });
+
+        // Create a fake bot
+        const mockConfig = {
+            meetingInfo: {
+                platform: 'mock-platform',
+            },
+        } as unknown as BotConfig;
+        const mockOnEvent = async (eventType: string, data?: any) => { /* mock event handler */ };
+        
+        //Create Mock Bot
+        const someBot = new Bot(mockConfig, mockOnEvent);
+        someBot.getRecordingPath = jest.fn(() => 'mock-path'); // Mock the getRecordingPath method to return the mock body
+        someBot.getContentType = jest.fn(() => 'mock-content-type'); // Mock the getContentType method to return the mock content type
+
+        //
+        // Test
+        await uploadRecordingToS3(s3Client, someBot);
+        //
+        
+        // Ensure the S3Client and PutObjectCommand were called with the correct parameters
+        expect(PutObjectCommand).toHaveBeenCalledWith({
+            Bucket: mockBucketName,
+            Key: mockKey,
+            Body: mockBody,
+        });
+        expect(s3Client.send).toHaveBeenCalledWith(putObjectCommand);
+    });
 });

--- a/src/bots/tests/teams_recording.test.ts
+++ b/src/bots/tests/teams_recording.test.ts
@@ -1,0 +1,97 @@
+import { MeetsBot } from "../meet/src/bot";
+import * as dotenv from 'dotenv';
+import { BotConfig } from "../src/types";
+import { TeamsBot } from "../teams/src/bot";
+import { ZoomBot } from "../zoom/src/bot";
+import { beforeAll, beforeEach, jest } from '@jest/globals';
+import exp from "constants";
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+// Ensure puppeteer-stream is not mocked
+jest.unmock('puppeteer-stream');
+
+// 
+// Bot Recording Tests as described in Section 2.1.2.4
+// Of our System Verification and Validation Document.
+// 
+
+//
+// Each of the Bot recording are in their seperate files because, for a reason I cannot find,
+//  the stream() is unavailable after the first test it is run. This doesn't impact the bot in production,
+// since we only ever send one .stream() request per bot.
+//
+
+// Create Mock Configs
+dotenv.config();
+const mockTeamsConfig = {
+    id: 0,
+    meetingInfo: JSON.parse(process.env.TEAMS_TEST_MEETING_INFO || '{}'),
+    automaticLeave: {
+        // automaticLeave: null, //Not included to see what happens on a bad config
+    }
+} as BotConfig;
+
+describe('Teams Bot Recording Test', () => {
+
+    // Cleanup
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+
+    it('Recording Dimension Test', async function () {
+
+        // Check if ffmpeg is available
+        try {
+            execSync('ffmpeg -version', { stdio: 'ignore' });
+        } catch (error) {
+            console.warn('Skipping test: ffmpeg is not available.');
+            this.skip();
+            return;
+        }
+
+        const bot = new TeamsBot(mockTeamsConfig, async (eventType: string, data: any) => { });
+        let recordingPath: string | null = null;
+
+        // Launch a broser
+        await bot.launchBrowser();
+        await new Promise((resolve) => setTimeout(resolve, 400));
+
+        // Start Recording
+        await bot.startRecording();
+        console.log('Started Recording')
+        await new Promise((resolve) => setTimeout(resolve, 10000));
+        console.log('Done holding.')
+
+        // Stop Recording
+        await bot.stopRecording();
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+
+        // Stop Recording
+        recordingPath = bot.getRecordingPath();
+
+        //End
+        await bot.endLife();
+
+        // Assertions
+        expect(recordingPath).toBeDefined();
+        const fileExists = fs.existsSync(recordingPath);
+        expect(fileExists).toBe(true); // Ensure file exists
+
+        // Check dimensions using ffprobe
+        const ffprobeOutput = execSync(`ffprobe -v error -select_streams v:0 -show_entries stream=width,height -of json "${recordingPath}"`);
+        const dimensions = JSON.parse(ffprobeOutput);
+        
+        // Delete the temp file once we have read in dimensions
+        if (recordingPath && fs.existsSync(recordingPath)) {
+            fs.unlinkSync(recordingPath);
+        }
+        
+        // TODO: Use an input to determine the expected dimension, pass that to the bot when recording start.
+        // No implementation for that yet.
+        expect(dimensions.streams[0].width).toBeGreaterThan(0);
+        expect(dimensions.streams[0].height).toBeGreaterThan(0);
+
+    }, 60000); // Set max timeout to 60 seconds
+});

--- a/src/bots/tests/zoom_recording.test.ts
+++ b/src/bots/tests/zoom_recording.test.ts
@@ -1,0 +1,97 @@
+import { MeetsBot } from "../meet/src/bot";
+import * as dotenv from 'dotenv';
+import { BotConfig } from "../src/types";
+import { TeamsBot } from "../teams/src/bot";
+import { ZoomBot } from "../zoom/src/bot";
+import { beforeAll, beforeEach, jest } from '@jest/globals';
+import exp from "constants";
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+// Ensure puppeteer-stream is not mocked
+jest.unmock('puppeteer-stream');
+
+// 
+// Bot Recording Tests as described in Section 2.1.2.4
+// Of our System Verification and Validation Document.
+// 
+
+//
+// Each of the Bot recording are in their seperate files because, for a reason I cannot find,
+//  the stream() is unavailable after the first test it is run. This doesn't impact the bot in production,
+// since we only ever send one .stream() request per bot.
+//
+
+// Create Mock Configs
+dotenv.config();
+const mockZoomConfig = {
+    id: 0,
+    meetingInfo: JSON.parse(process.env.ZOOM_TEST_MEETING_INFO || '{}'),
+    automaticLeave: {
+        // automaticLeave: null, //Not included to see what happens on a bad config
+    }
+} as BotConfig;
+
+describe('Zoom Bot Recording Test', () => {
+
+    // Cleanup
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+
+    it('Recording Dimension Test', async function () {
+
+        // Check if ffmpeg is available
+        try {
+            execSync('ffmpeg -version', { stdio: 'ignore' });
+        } catch (error) {
+            console.warn('Skipping test: ffmpeg is not available.');
+            this.skip();
+            return;
+        }
+
+        const bot = new ZoomBot(mockZoomConfig, async (eventType: string, data: any) => { });
+        let recordingPath: string | null = null;
+
+        // Launch a broser
+        await bot.launchBrowser();
+        await new Promise((resolve) => setTimeout(resolve, 400));
+
+        // Start Recording
+        await bot.startRecording();
+        console.log('Started Recording')
+        await new Promise((resolve) => setTimeout(resolve, 10000));
+        console.log('Done holding.')
+
+        // Stop Recording
+        await bot.stopRecording();
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+
+        // Stop Recording
+        recordingPath = bot.getRecordingPath();
+
+        //End
+        await bot.endLife();
+
+        // Assertions
+        expect(recordingPath).toBeDefined();
+        const fileExists = fs.existsSync(recordingPath);
+        expect(fileExists).toBe(true); // Ensure file exists
+
+        // Check dimensions using ffprobe
+        const ffprobeOutput = execSync(`ffprobe -v error -select_streams v:0 -show_entries stream=width,height -of json "${recordingPath}"`);
+        const dimensions = JSON.parse(ffprobeOutput);
+        
+        // Delete the temp file once we have read in dimensions
+        if (recordingPath && fs.existsSync(recordingPath)) {
+            fs.unlinkSync(recordingPath);
+        }
+        
+        // TODO: Use an input to determine the expected dimension, pass that to the bot when recording start.
+        // No implementation for that yet.
+        expect(dimensions.streams[0].width).toBeGreaterThan(0);
+        expect(dimensions.streams[0].height).toBeGreaterThan(0);
+
+    }, 60000); // Set max timeout to 60 seconds
+});

--- a/src/bots/zoom/src/bot.ts
+++ b/src/bots/zoom/src/bot.ts
@@ -56,12 +56,10 @@ export class ZoomBot extends Bot {
     return false;
   }
 
-
-  /**
-   * Opens a browser and navigatges, joins the meeting.
-   * @returns {Promise<void>}
+  /** Launch browser
+   * 
    */
-  async joinMeeting() {
+  async launchBrowser() {
 
     // Launch a browser and open the meeting
     this.browser = await launch({
@@ -89,11 +87,26 @@ export class ZoomBot extends Bot {
     context.overridePermissions(urlObj.origin, ["camera", "microphone"]);
     console.log('Turned off camera & mic permissions')
 
-    // Opens a new page
-    const page = await this.browser.newPage();
-    this.page = page;
+    // Opens a new page in the browser
+    this.page = await this.browser.newPage();
+  }
+
+
+  /**
+   * Opens a browser and navigatges, joins the meeting.
+   * @returns {Promise<void>}
+   */
+  async joinMeeting() {
+
+    // Launch
+    await this.launchBrowser();
+
+    // Create a URL object from the url
+    const page = this.page;
+    const urlObj = new URL(this.url);
     
     // Navigates to the url
+    console.log("Atempting to open link");
     await page.goto(urlObj.href);
     console.log("Page opened");
 
@@ -121,7 +134,7 @@ export class ZoomBot extends Bot {
 
       // Waits for the input field and types the name from the config
       await frame.waitForSelector("#input-for-name");
-      await frame.type("#input-for-name", this.settings.botDisplayName);
+      await frame.type("#input-for-name", this.settings?.botDisplayName ?? "Meeting Bot");
       console.log("Typed name");
 
       // Clicks the join button


### PR DESCRIPTION
### TL;DR

Enhanced bot testing infrastructure with improved mocks, recording capabilities, and error handling.

### What changed?

- Enhanced AWS S3 client mocks to better track parameters and method calls
- Added file system mocks for testing file operations
- Refactored puppeteer-stream mocks for better logging and structure
- Improved browser handling in bots by extracting `launchBrowser()` method from `joinMeeting()`
- Added specialized recording tests for Meet, Teams, and Zoom bots
- Added custom `MeetingJoinError` class for better error handling
- Implemented `getFFmpegParams()` in MeetsBot to support testing environments
- Added S3 upload testing capabilities
- Enhanced screenshot error handling with try/catch blocks
- Improved bot navigation tests with better error handling

### How to test?

1. Run the test suite with `pnpm test` to verify all mocks work correctly
2. For recording tests, ensure ffmpeg is available in your environment.
3. For navigation tests, ensure valid meeting URLs are provided in environment variables

Can use the command `pnpm exec jest <file>` to run a specific test suite.

### Why make this change?

This change improves the testing infrastructure to better validate bot functionality across different platforms. By separating browser launching from meeting joining logic, we've made the code more modular and easier to test. The enhanced mocks provide better visibility into how the bots interact with external services, while the specialized recording tests ensure that video capture works correctly across all supported platforms. These improvements align with the System Verification and Validation Document requirements in sections 2.1.2.1 through 2.1.2.4.