### PR TITLE
refactor: move auth mock outside for re-use

### DIFF
--- a/src/server/src/__mocks__/next-auth/react.ts
+++ b/src/server/src/__mocks__/next-auth/react.ts
@@ -1,0 +1,9 @@
+/**
+ * This file is used to mock the next-auth/react module used by front-end code to get the user's session.
+ */
+
+// Create a mock function for useSession
+const useSession = jest.fn();
+
+// Export the mock function
+export { useSession };

--- a/src/server/src/app/__tests__/page.test.tsx
+++ b/src/server/src/app/__tests__/page.test.tsx
@@ -5,9 +5,7 @@ import { useSession } from "next-auth/react";
 import { api } from "~/trpc/react";
 
 // Mock the auth and API modules
-jest.mock("next-auth/react", () => ({
-  useSession: jest.fn(),
-}));
+jest.mock("next-auth/react");
 
 jest.mock("~/trpc/react", () => ({
   api: {


### PR DESCRIPTION
### TL;DR

Created a dedicated mock for next-auth/react to improve test maintainability.

### What changed?

- Added a new mock file `src/__mocks__/next-auth/react.ts` that provides a mock implementation of the `useSession` function
- Updated the page test to use the centralized mock instead of an inline mock definition

### How to test?

1. Run the existing tests to ensure they still pass with the new mock implementation
2. Verify that the test behavior remains consistent

### Why make this change?

This change improves the maintainability of tests by centralizing the mock implementation for next-auth/react. By moving the mock to a dedicated file, we ensure consistent mocking behavior across all tests and make it easier to update the mock in the future if the next-auth API changes.