### PR TITLE
refactor: move trpc api mock outside for re-use

### DIFF
--- a/src/server/eslint.config.js
+++ b/src/server/eslint.config.js
@@ -48,6 +48,20 @@ export default tseslint.config(
       ],
     },
   },
+  // Special rules for test files
+  {
+    files: [
+      "**/__tests__/**/*.ts",
+      "**/__tests__/**/*.tsx",
+      "**/*.test.ts",
+      "**/*.test.tsx",
+    ],
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+      "@typescript-eslint/no-var-requires": "off",
+      "@typescript-eslint/consistent-type-imports": "off",
+    },
+  },
   {
     linterOptions: {
       reportUnusedDisableDirectives: true,

--- a/src/server/src/app/__tests__/page.test.tsx
+++ b/src/server/src/app/__tests__/page.test.tsx
@@ -1,23 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import Home from "../page";
-import { useSession } from "next-auth/react";
-import { api } from "~/trpc/react";
+import { createTrpcApiMock, mockUseQuery } from "~/lib/testUtils";
 
-// Mock the auth and API modules
 jest.mock("next-auth/react");
+jest.mock("~/trpc/react", () => createTrpcApiMock());
 
-jest.mock("~/trpc/react", () => ({
-  api: {
-    apiKeys: {
-      getApiKeyCount: {
-        useQuery: jest.fn(),
-      },
-    },
-  },
-}));
-
-// Mock components
+// Mock Dashboards~ We are only concerned with which dashboard is rendered (rather than the functionalit of each Dashboard)
 jest.mock("../components/Dashboard", () => ({
   __esModule: true,
   default: () => <div data-testid="dashboard">Dashboard Component</div>,
@@ -30,6 +18,12 @@ jest.mock("../components/WelcomeDashboard", () => ({
   ),
 }));
 
+// Explicitly import the components *after* the mocks
+const { default: Home } = require("../page") as typeof import("../page");
+const { useSession } =
+  require("next-auth/react") as typeof import("next-auth/react");
+const { api } = require("~/trpc/react") as typeof import("~/trpc/react");
+
 // Clear mock data before each test
 beforeEach(() => {
   jest.clearAllMocks();
@@ -38,18 +32,19 @@ beforeEach(() => {
 describe("Home", () => {
   it("If the user is not signed in, they will see the Welcome Dashboard", () => {
     // ARRANGE
-    // Mock useSession to return null (not logged in)
+    // user is not signed in
     jest.mocked(useSession).mockReturnValue({
       data: null,
       status: "unauthenticated",
       update: async () => null,
     });
 
-    // Mock useQuery to not be called when not authenticated
-    // @ts-expect-error - I am not mocking the complete useQuery hook, just the parts that are being used in the component
-    jest.mocked(api.apiKeys.getApiKeyCount.useQuery).mockReturnValue({
-      data: undefined,
-    });
+    // no key count is fetched
+    jest.mocked(api.apiKeys.getApiKeyCount.useQuery).mockReturnValue(
+      mockUseQuery({
+        data: undefined,
+      }),
+    );
 
     // ACT
     render(<Home />);
@@ -61,7 +56,7 @@ describe("Home", () => {
 
   it("If the user has not yet created an API key, they will see the Welcome Dashboard", () => {
     // ARRANGE
-    // Mock useSession to return authenticated user
+    // user is authenticated
     jest.mocked(useSession).mockReturnValue({
       data: {
         user: {
@@ -73,10 +68,12 @@ describe("Home", () => {
       update: async () => null,
     });
 
-    // @ts-expect-error - I am not mocking the complete useQuery hook, just the parts that are being used in the component
-    jest.mocked(api.apiKeys.getApiKeyCount.useQuery).mockReturnValue({
-      data: { count: 0 },
-    });
+    // key count is 0
+    jest.mocked(api.apiKeys.getApiKeyCount.useQuery).mockReturnValue(
+      mockUseQuery({
+        data: { count: 0 },
+      }),
+    );
 
     // ACT
     render(<Home />);
@@ -88,7 +85,7 @@ describe("Home", () => {
 
   it("If the user has created an API key, they will see the Dashboard", () => {
     // ARRANGE
-    // Mock useSession to return authenticated user
+    // user is authenticated
     jest.mocked(useSession).mockReturnValue({
       data: {
         user: {
@@ -100,10 +97,12 @@ describe("Home", () => {
       update: async () => null,
     });
 
-    // @ts-expect-error - I am not mocking the complete useQuery hook, just the parts that are being used in the component
-    jest.mocked(api.apiKeys.getApiKeyCount.useQuery).mockReturnValue({
-      data: { count: 1 },
-    });
+    // key count is 1
+    jest.mocked(api.apiKeys.getApiKeyCount.useQuery).mockReturnValue(
+      mockUseQuery({
+        data: { count: 1 },
+      }),
+    );
 
     // ACT
     render(<Home />);
@@ -115,6 +114,7 @@ describe("Home", () => {
 
   it("If auth is loading, the page will show a skeleton", () => {
     // ARRANGE
+    // auth is loading
     jest.mocked(useSession).mockReturnValue({
       data: null,
       status: "loading",
@@ -130,10 +130,12 @@ describe("Home", () => {
 
   it("If trpc query is loading, the page will show a skeleton", () => {
     // ARRANGE
-    // @ts-expect-error - I am not mocking the complete useQuery hook, just the parts that are being used in the component
-    jest.mocked(api.apiKeys.getApiKeyCount.useQuery).mockReturnValue({
-      data: undefined,
-    });
+    // key count is loading
+    jest.mocked(api.apiKeys.getApiKeyCount.useQuery).mockReturnValue(
+      mockUseQuery({
+        data: undefined,
+      }),
+    );
 
     // ACT
     render(<Home />);
@@ -144,7 +146,7 @@ describe("Home", () => {
 
   it("If trpc query threw an error, the page will show an error alert", () => {
     // ARRANGE
-
+    // user is authenticated
     jest.mocked(useSession).mockReturnValue({
       data: {
         user: {
@@ -156,13 +158,14 @@ describe("Home", () => {
       update: async () => null,
     });
 
-    jest.mocked(api.apiKeys.getApiKeyCount.useQuery).mockReturnValue({
-      // @ts-expect-error - I am not mocking the complete useQuery hook, just the parts that are being used in the component
-      error: {
-        message: "Test error",
-      },
-      isLoading: false,
-    });
+    // key count is an error
+    jest.mocked(api.apiKeys.getApiKeyCount.useQuery).mockReturnValue(
+      mockUseQuery({
+        error: {
+          message: "Test error",
+        },
+      }),
+    );
 
     // ACT
     render(<Home />);

--- a/src/server/src/lib/testUtils.ts
+++ b/src/server/src/lib/testUtils.ts
@@ -1,0 +1,123 @@
+import {
+  type TRPC_ERROR_CODE_KEY,
+  type TRPC_ERROR_CODE_NUMBER,
+} from "@trpc/server/rpc";
+import {
+  type UseTRPCMutationResult,
+  type UseTRPCQueryResult,
+} from "@trpc/react-query/shared";
+import { type TRPCClientErrorLike } from "@trpc/client";
+import type { typeToFlattenedError } from "zod";
+import type { UseMutateAsyncFunction } from "@tanstack/react-query";
+
+/**
+ * This is a utility function to create a mock for React Query.
+ * It is used to mock the useQuery, useMutation, and invalidate hooks, which are the only hooks used in the frontend.
+ * It is used in the test files to mock the API responses.
+ * Note: We use the Type variable M to avoid explicitly importing react here (it will cause react-related errors)
+ */
+
+interface TrpcApiMock {
+  [key: string]: jest.Mock | TrpcApiMock;
+}
+
+const createTrpcApiMock = (): TrpcApiMock => {
+  return new Proxy({} as TrpcApiMock, {
+    get: (target, prop: string) => {
+      if (!(prop in target)) {
+        if (
+          prop === "useQuery" ||
+          prop === "useMutation" ||
+          prop === "invalidate" ||
+          prop === "useUtils"
+        ) {
+          target[prop] = jest.fn();
+        } else {
+          target[prop] = createTrpcApiMock();
+        }
+      }
+
+      return target[prop];
+    },
+  });
+};
+
+/**
+ * This is a utility function to create a valid return value (no type errors) for useQuery
+ */
+
+type useQueryMockInput<OutputType> = {
+  data?: OutputType;
+  error?: {
+    message: string;
+  };
+  isLoading?: boolean;
+};
+
+type clientError<InputType, OutputType> = TRPCClientErrorLike<{
+  input: InputType;
+  output: OutputType;
+  transformer: true;
+  errorShape: {
+    data: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      zodError: typeToFlattenedError<any, string> | null;
+      code: TRPC_ERROR_CODE_KEY;
+      httpStatus: number;
+      path?: string;
+      stack?: string;
+    };
+    message: string;
+    code: TRPC_ERROR_CODE_NUMBER;
+  };
+}>;
+
+type useQueryResults<InputType, OutputType> = UseTRPCQueryResult<
+  InputType,
+  clientError<InputType, OutputType>
+>;
+
+const mockUseQuery = <InputType, OutputType>({
+  data,
+  error,
+  isLoading,
+}: useQueryMockInput<OutputType>): useQueryResults<InputType, OutputType> => {
+  return {
+    data,
+    error: error ? { message: error.message } : null,
+    isLoading: error ? false : (isLoading ?? false),
+  } as useQueryResults<InputType, OutputType>;
+};
+
+/**
+ * This is a utility function to create a valid return value (no type errors) for useMutation
+ */
+
+type useMutationMockInput = {
+  isPending?: boolean;
+  mutateAsync?: jest.Mock;
+};
+
+type useMutationResults<InputType, OutputType> = UseTRPCMutationResult<
+  OutputType,
+  clientError<InputType, OutputType>,
+  InputType,
+  unknown
+>;
+
+const mockUseMutation = <InputType, OutputType>({
+  isPending,
+  mutateAsync,
+}: useMutationMockInput): useMutationResults<InputType, OutputType> => {
+  return {
+    isPending: isPending ?? false,
+    mutateAsync: (mutateAsync ?? jest.fn()) as UseMutateAsyncFunction<
+      OutputType,
+      clientError<InputType, OutputType>,
+      InputType,
+      unknown
+    >,
+  } as unknown as useMutationResults<InputType, OutputType>;
+};
+
+export { createTrpcApiMock, mockUseQuery, mockUseMutation };


### PR DESCRIPTION
### TL;DR

Improved test utilities and ESLint configuration for better testing experience.

*Note* I tried my best to make a manual mock, i.e. under some `__mock__` folder, for `~/trpc/react`, but ran into the most obscure errors that had to do with React internals or the specific order in which Jest imports libraries. In order to make at least this helper function work, I needed to use `require` to be specific about the order in which libraries are to be imported.

### What changed?

- Added special ESLint rules for test files to disable certain TypeScript restrictions
- Created new test utility functions in `src/lib/testUtils.ts`:
  - `createTrpcApiMock()`: Creates a mock for tRPC API
  - `mockUseQuery()`: Generates properly typed mock return values for useQuery
  - `mockUseMutation()`: Generates properly typed mock return values for useMutation
- Refactored the page test to use these new utilities, removing TypeScript errors and improving readability

### How to test?

1. Run the test suite to verify all tests pass: `npm test`
2. Check that TypeScript doesn't show any errors in the test files
3. Verify ESLint doesn't flag any issues in test files related to imports or type consistency

### Why make this change?

The previous test implementation had several TypeScript errors and used error-prone mocking approaches. This change:

1. Eliminates TypeScript errors in tests by providing properly typed mock utilities
2. Makes tests more maintainable with cleaner mocking patterns
3. Relaxes certain ESLint rules specifically for test files where strict typing requirements can hinder testing
4. Improves test readability with more explicit mocking and better comments