### PR TITLE
refactor: move use session mock outside for re-use

### DIFF
--- a/src/server/src/app/__tests__/page.test.tsx
+++ b/src/server/src/app/__tests__/page.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { createTrpcApiMock, mockUseQuery } from "~/lib/testUtils";
+import {
+  createTrpcApiMock,
+  mockUseQuery,
+  mockUseSession,
+} from "~/lib/testUtils";
 
 jest.mock("next-auth/react");
 jest.mock("~/trpc/react", () => createTrpcApiMock());
@@ -57,16 +61,9 @@ describe("Home", () => {
   it("If the user has not yet created an API key, they will see the Welcome Dashboard", () => {
     // ARRANGE
     // user is authenticated
-    jest.mocked(useSession).mockReturnValue({
-      data: {
-        user: {
-          id: "fake_user_id",
-        },
-        expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
-      },
-      status: "authenticated",
-      update: async () => null,
-    });
+    jest
+      .mocked(useSession)
+      .mockReturnValue(mockUseSession({ status: "authenticated" }));
 
     // key count is 0
     jest.mocked(api.apiKeys.getApiKeyCount.useQuery).mockReturnValue(
@@ -86,16 +83,9 @@ describe("Home", () => {
   it("If the user has created an API key, they will see the Dashboard", () => {
     // ARRANGE
     // user is authenticated
-    jest.mocked(useSession).mockReturnValue({
-      data: {
-        user: {
-          id: "fake_user_id",
-        },
-        expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
-      },
-      status: "authenticated",
-      update: async () => null,
-    });
+    jest
+      .mocked(useSession)
+      .mockReturnValue(mockUseSession({ status: "authenticated" }));
 
     // key count is 1
     jest.mocked(api.apiKeys.getApiKeyCount.useQuery).mockReturnValue(
@@ -147,16 +137,9 @@ describe("Home", () => {
   it("If trpc query threw an error, the page will show an error alert", () => {
     // ARRANGE
     // user is authenticated
-    jest.mocked(useSession).mockReturnValue({
-      data: {
-        user: {
-          id: "fake_user_id",
-        },
-        expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
-      },
-      status: "authenticated",
-      update: async () => null,
-    });
+    jest
+      .mocked(useSession)
+      .mockReturnValue(mockUseSession({ status: "authenticated" }));
 
     // key count is an error
     jest.mocked(api.apiKeys.getApiKeyCount.useQuery).mockReturnValue(

--- a/src/server/src/lib/testUtils.ts
+++ b/src/server/src/lib/testUtils.ts
@@ -9,6 +9,7 @@ import {
 import { type TRPCClientErrorLike } from "@trpc/client";
 import type { typeToFlattenedError } from "zod";
 import type { UseMutateAsyncFunction } from "@tanstack/react-query";
+import type { SessionContextValue } from "next-auth/react";
 
 /**
  * This is a utility function to create a mock for React Query.
@@ -120,4 +121,41 @@ const mockUseMutation = <InputType, OutputType>({
   } as unknown as useMutationResults<InputType, OutputType>;
 };
 
-export { createTrpcApiMock, mockUseQuery, mockUseMutation };
+/**
+ * This is a utility function to create a valid session object (no type errors) for useSession
+ */
+
+type useSessionInput = {
+  status: "authenticated" | "unauthenticated" | "loading";
+};
+
+const mockUseSession = ({
+  status,
+}: useSessionInput): SessionContextValue<false> => {
+  const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000);
+  switch (status) {
+    case "authenticated":
+      return {
+        data: {
+          user: { id: "fake_user_id" },
+          expires: tomorrow.toISOString(),
+        },
+        status: "authenticated",
+        update: jest.fn(),
+      };
+    case "unauthenticated":
+      return {
+        data: null,
+        status: "unauthenticated",
+        update: jest.fn(),
+      };
+    case "loading":
+      return {
+        data: null,
+        status: "loading",
+        update: jest.fn(),
+      };
+  }
+};
+
+export { createTrpcApiMock, mockUseQuery, mockUseMutation, mockUseSession };


### PR DESCRIPTION
### TL;DR

Added a `mockUseSession` utility function to simplify test setup for authenticated sessions.

### What changed?

- Created a new `mockUseSession` utility function in `testUtils.ts` that generates a properly typed session object for testing
- Updated the page tests to use this new utility function instead of manually creating session objects
- Exported the new utility function alongside existing test utilities

### How to test?

1. Run the existing tests to ensure they still pass with the new utility function
2. Try using the new `mockUseSession` utility in other test files that need to mock authentication

### Why make this change?

The previous approach required duplicating session object creation code across multiple test cases. This refactoring improves code maintainability by centralizing the session mocking logic into a reusable utility function, making tests more concise and reducing duplication. It also ensures type safety when mocking session objects.