### PR TITLE
refactor:bot-test-env

### DIFF
--- a/src/bots/.env.example
+++ b/src/bots/.env.example
@@ -7,10 +7,5 @@ AWS_REGION=your_region
 # Usefull for debugging. If you set to =false, then any failure in the heartbeat ping will not be logged.
 HEARTBEAT_DEBUG=true
 
-# Bot Data used for testing. This is a mock data that will be used for testing purposes only. JSON as String structure
-TEAMS_TEST_MEETING_INFO='{"meetingId": "", "organizerId": "", "tenantId": ""}'
-MEET_TEST_MEETING_INFO='{"meetingUrl": "https://meet.google.com/abc-defg-hij"}'
-ZOOM_TEST_MEETING_INFO='{"meetingId":"", "meetingPassword":""}'
-
-# Bot data (example - this will be set by the backend) -- SEE envBotDataExample.ts for how to generate this
-BOT_DATA={"botId":1,"meetingInfo":{},"botName":"Meeting Bot","recordingPath":"./recording.mp4","automaticLeave":{"waitingRoomTimeout":300000,"noOneJoinedTimeout":300000,"everyoneLeftTimeout":300000}}
+# Bot data (example - this will be set by the backend)
+BOT_DATA={"botId":1,"meetingUrl":"https://meet.google.com/xxx-xxxx-xxx","botName":"Meeting Bot","recordingPath":"./recording.mp4","automaticLeave":{"waitingRoomTimeout":300000,"noOneJoinedTimeout":300000,"everyoneLeftTimeout":300000}}

--- a/src/bots/src/monitoring.ts
+++ b/src/bots/src/monitoring.ts
@@ -1,6 +1,10 @@
 import { EventCode, Status } from "./types";
 import { trpc } from "./trpc";
 import { setTimeout } from "timers/promises";
+import dotenv from "dotenv";
+
+// Load the test.env file (overrides variables from .env if they overlap)
+dotenv.config({ path: 'test.env' });
 
 // Start heartbeat loop in the background
 export const startHeartbeat = async (

--- a/src/bots/test.env
+++ b/src/bots/test.env
@@ -1,0 +1,6 @@
+# This file contains environment variables that are helpful during the development phase.
+# These flags are not strictly required in your environment but can assist with debugging and testing.
+
+# When set to =false, then any heartbeat ping failure will not be logged.
+# If DNE or =true, then any heartbeat ping failure will be logged.
+HEARTBEAT_DEBUG=false


### PR DESCRIPTION
### TL;DR

Added a new test environment configuration file and improved heartbeat debugging options.

### What changed?

- Created a new `test.env` file for development-specific environment variables
- Removed `HEARTBEAT_DEBUG` from `.env.example` and moved it to `test.env`
- Updated the monitoring module to load the `test.env` file, which will override any overlapping variables from `.env`
- Improved documentation for the `HEARTBEAT_DEBUG` flag, clarifying its behavior when not defined

### How to test?

1. Create a `test.env` file in the `src/bots` directory with your desired debug settings
2. Run the bot and verify that heartbeat ping failures are logged or suppressed based on your `HEARTBEAT_DEBUG` setting
3. Confirm that the monitoring module correctly loads variables from both `.env` and `test.env` files

### Why make this change?

This change separates development-specific configuration from the standard environment setup, making it easier to maintain different settings between environments. By moving debugging flags to a dedicated test environment file, we can keep the main `.env` file cleaner while providing developers with more flexibility during testing and debugging.