### PR TITLE
fix: add missing jest imports

### DIFF
--- a/src/bots/__mocks__/@aws-sdk/client-s3.ts
+++ b/src/bots/__mocks__/@aws-sdk/client-s3.ts
@@ -1,3 +1,5 @@
+import { jest } from '@jest/globals';
+
 const S3Client = jest.fn(function (params) {
 	console.log('S3Client called with params:', params);
 	this.send = jest.fn((params) => {

--- a/src/bots/__mocks__/fs.ts
+++ b/src/bots/__mocks__/fs.ts
@@ -1,3 +1,5 @@
+import { jest } from '@jest/globals';
+
 // Log reading in a file -- pass back empty file content
 const readFileSync = jest.fn((path: string) => {
     console.log('Mocking Reading In a file:', path);

--- a/src/bots/__mocks__/puppeteer-stream.ts
+++ b/src/bots/__mocks__/puppeteer-stream.ts
@@ -1,3 +1,5 @@
+import { jest } from '@jest/globals';
+
 // Mock Puppeteer-stream (called in ../zoom/src/bot.ts)
 const launch = jest.fn(() => {
     

--- a/src/bots/__mocks__/superjson.ts
+++ b/src/bots/__mocks__/superjson.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 
 const superjson = {
     serialize: jest.fn((data) => ({ json: JSON.stringify(data), meta: null })),

--- a/src/bots/tests/bot.test.ts
+++ b/src/bots/tests/bot.test.ts
@@ -3,6 +3,7 @@ import { MeetsBot } from "../meet/src/bot";
 import { BotConfig } from "../src/types";
 import { ZoomBot } from "../zoom/src/bot";
 import { TeamsBot } from "../teams/src/bot";
+import { jest, it, expect, describe, afterEach, beforeEach, afterAll, beforeAll } from '@jest/globals';
 
 
 // 

--- a/src/bots/tests/bot_exit.test.ts
+++ b/src/bots/tests/bot_exit.test.ts
@@ -3,7 +3,7 @@ import * as dotenv from 'dotenv';
 import { BotConfig } from "../src/types";
 import { TeamsBot } from "../teams/src/bot";
 import { ZoomBot } from "../zoom/src/bot";
-import { beforeAll, beforeEach, jest } from '@jest/globals';
+import { beforeAll, beforeEach, afterEach, afterAll, jest, describe, expect, it } from '@jest/globals';
 import exp from "constants";
 
 

--- a/src/bots/tests/bot_nav.test.ts
+++ b/src/bots/tests/bot_nav.test.ts
@@ -3,7 +3,7 @@ import * as dotenv from 'dotenv';
 import { BotConfig, MeetingJoinError, WaitingRoomTimeoutError } from "../src/types";
 import { TeamsBot } from "../teams/src/bot";
 import { ZoomBot } from "../zoom/src/bot";
-import { jest } from '@jest/globals';
+import { jest, it, expect, describe, afterEach, beforeEach, afterAll, beforeAll } from '@jest/globals';
 
 // 
 // Bot Unit Nav Tests as described in Section 2.1.2.1

--- a/src/bots/tests/meet_recording.test.ts
+++ b/src/bots/tests/meet_recording.test.ts
@@ -3,7 +3,8 @@ import * as dotenv from 'dotenv';
 import { BotConfig } from "../src/types";
 import { TeamsBot } from "../teams/src/bot";
 import { ZoomBot } from "../zoom/src/bot";
-import { beforeAll, beforeEach, jest } from '@jest/globals';
+import { beforeAll, beforeEach, afterEach, afterAll, jest, describe, expect, it } from '@jest/globals';
+
 import exp from "constants";
 const fs = require('fs');
 const { execSync } = require('child_process');

--- a/src/bots/tests/s3startup.test.ts
+++ b/src/bots/tests/s3startup.test.ts
@@ -1,7 +1,7 @@
 import { createS3Client, uploadRecordingToS3 } from '../src/s3';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { S3Client } from '@aws-sdk/client-s3';
-import {describe, expect, test, jest, it} from '@jest/globals';
+import { jest, it, expect, describe, afterEach, beforeEach, afterAll, beforeAll } from '@jest/globals';
 import fs from 'fs';
 import { BotConfig } from '../src/types';
 import { Bot } from '../src/bot';

--- a/src/bots/tests/teams_recording.test.ts
+++ b/src/bots/tests/teams_recording.test.ts
@@ -3,7 +3,7 @@ import * as dotenv from 'dotenv';
 import { BotConfig } from "../src/types";
 import { TeamsBot } from "../teams/src/bot";
 import { ZoomBot } from "../zoom/src/bot";
-import { beforeAll, beforeEach, jest } from '@jest/globals';
+import { beforeAll, beforeEach, afterEach, afterAll, jest, describe, expect, it } from '@jest/globals';
 import exp from "constants";
 const fs = require('fs');
 const { execSync } = require('child_process');

--- a/src/bots/tests/zoom_recording.test.ts
+++ b/src/bots/tests/zoom_recording.test.ts
@@ -3,8 +3,9 @@ import * as dotenv from 'dotenv';
 import { BotConfig } from "../src/types";
 import { TeamsBot } from "../teams/src/bot";
 import { ZoomBot } from "../zoom/src/bot";
-import { beforeAll, beforeEach, jest } from '@jest/globals';
+import { beforeAll, beforeEach, afterEach, afterAll, jest, describe, expect, it } from '@jest/globals';
 import exp from "constants";
+
 const fs = require('fs');
 const { execSync } = require('child_process');
 


### PR DESCRIPTION
### TL;DR

Added explicit Jest imports to all test files and mocks to ensure proper Jest functionality. Sometimes I didn't even get the errors, and I wasn't sure why. Tests still worked without these imports, it just makes ESLint shut up. 