### PR TITLE
fix:use-passed-in-heartbeat-interval

### DIFF
--- a/src/bots/src/index.ts
+++ b/src/bots/src/index.ts
@@ -43,7 +43,8 @@ export const main = async () => {
 
   // Start heartbeat in the background
   console.log("Starting heartbeat");
-  startHeartbeat(botId, heartbeatController.signal); 
+  const heartbeatInterval = botData.heartbeatInterval ?? 5000; // Default to 5 seconds if not set
+  startHeartbeat(botId, heartbeatController.signal, heartbeatInterval); 
 
   // Report READY_TO_DEPLOY event
   await reportEvent(botId, EventCode.READY_TO_DEPLOY);

--- a/src/bots/src/monitoring.ts
+++ b/src/bots/src/monitoring.ts
@@ -9,7 +9,8 @@ dotenv.config({ path: 'test.env' });
 // Start heartbeat loop in the background
 export const startHeartbeat = async (
   botId: number,
-  abortSignal: AbortSignal
+  abortSignal: AbortSignal,
+  intervalMs: number = 5000
 ) => {
   while (!abortSignal.aborted) {
     try {
@@ -21,7 +22,7 @@ export const startHeartbeat = async (
       if ((process.env?.HEARTBEAT_DEBUG ?? 'true') !== 'false')
         console.error("Failed to send heartbeat:", error);
     }
-    await setTimeout(5000); // Send heartbeat every 5 seconds
+    await setTimeout(intervalMs); // Send heartbeat every 5 seconds
   }
 };
 


### PR DESCRIPTION
### TL;DR

Added configurable heartbeat interval for bots

### What changed?

- Modified `startHeartbeat` function to accept a configurable interval parameter (defaulting to 5000ms)
- Updated the main function to read the heartbeat interval from `botData` configuration
- Added fallback to 5 seconds if the interval is not specified in the bot configuration

### How to test?

1. Configure a bot with a custom heartbeat interval by setting `heartbeatInterval` in the bot configuration
2. Deploy the bot and verify in logs that heartbeats are being sent at the configured interval
3. Test with a bot that doesn't specify the interval to confirm it defaults to 5 seconds

### Why make this change?

This change allows for more flexible monitoring configurations based on specific bot requirements. Some bots may need more frequent health checks, while others can operate with less frequent heartbeats to reduce network traffic and processing overhead.