### PR TITLE
saftey:ensure-docker-and-platform-match

### DIFF
--- a/src/bots/meet/Dockerfile
+++ b/src/bots/meet/Dockerfile
@@ -41,6 +41,9 @@ RUN mkdir -p /root/ms-playwright && chmod -R 777 /root/ms-playwright
 # Runtime stage
 FROM mcr.microsoft.com/playwright:v1.51.0-jammy AS runtime
 
+# Get meeting platform this file is built for
+ENV DOCKER_MEETING_PLATFORM=meet
+
 # Set the working directory inside the container
 WORKDIR /app
 

--- a/src/bots/teams/Dockerfile
+++ b/src/bots/teams/Dockerfile
@@ -5,7 +5,9 @@ ENV \
     # Configure default locale (important for chrome-headless-shell).
     LANG=en_US.UTF-8 \
     # UID of the non-root user 'pptruser'
-    PPTRUSER_UID=10042 
+    PPTRUSER_UID=10042 \
+    # Get meeting platform this file is built for
+    DOCKER_MEETING_PLATFORM=teams
     
 # Stay as root for all installation steps
 USER root

--- a/src/bots/zoom/Dockerfile
+++ b/src/bots/zoom/Dockerfile
@@ -5,7 +5,9 @@ ENV \
     # Configure default locale (important for chrome-headless-shell).
     LANG=en_US.UTF-8 \
     # UID of the non-root user 'pptruser'
-    PPTRUSER_UID=10042
+    PPTRUSER_UID=10042 \
+    # Get meeting platform this file is built for
+    DOCKER_MEETING_PLATFORM=zoom
     
 # Stay as root for all installation steps
 USER root


### PR DESCRIPTION
### TL;DR

Added platform validation to ensure bots run on the correct Docker image.

### What changed?

- Added `DOCKER_MEETING_PLATFORM` environment variable to all platform Dockerfiles (meet, teams, zoom)
- Enhanced the `createBot` function to validate that the bot's platform matches the Docker image it's running on
- Added error handling to prevent bots from running on mismatched Docker images
- Created a `validPlatformForImage` helper function to check platform compatibility
- Added special handling for "google" platform to match with "meet" image name

### How to test?

1. Build each platform's Docker image
2. Try to run a bot with a platform that doesn't match the Docker image (e.g., run a Teams bot on a Zoom Docker image)
3. Verify that an error is thrown with the message: "Docker image name [image] does not match platform [platform]"
4. Run a bot with the correct platform and verify it works as expected

### Why make this change?

This change adds a safety mechanism to prevent configuration errors where a bot might be deployed to the wrong platform's Docker image. By validating the platform at runtime, we can catch these misconfigurations early and provide clear error messages, preventing unexpected behavior and making debugging easier.