### PR TITLE
fix:bot-screenshots

### DIFF
--- a/src/bots/meet/src/bot.ts
+++ b/src/bots/meet/src/bot.ts
@@ -414,8 +414,10 @@ export class MeetsBot extends Bot {
   }
 
   async screenshot(fName: string = 'screenshot.png') {
-    if (!this.page) throw new Error("Page not initialized");
     try {
+      if (!this.page) throw new Error("Page not initialized");
+      if (!this.browser) throw new Error("Browser not initialized");
+
       const screenshot = await this.page.screenshot({
         type: "png",
       });

--- a/src/bots/teams/src/bot.ts
+++ b/src/bots/teams/src/bot.ts
@@ -42,20 +42,20 @@ export class TeamsBot extends Bot {
   }
 
   async screenshot(fName: string = "screenshot.png") {
-    if (!this.page) throw new Error("Page not initialized");
-
     try {
+      if (!this.page) throw new Error("Page not initialized");
+      if (!this.browser) throw new Error("Browser not initialized");
+
       const screenshot = await this.page.screenshot({
         type: "png",
-        encoding: "binary",
       });
 
       // Save the screenshot to a file
       const screenshotPath = path.resolve(`/tmp/${fName}`);
       fs.writeFileSync(screenshotPath, screenshot);
       console.log(`Screenshot saved to ${screenshotPath}`);
-    } catch (error) {
-      console.log("Error taking screenshot:", error);
+    } catch (e) {
+      console.log('Error taking screenshot:', e);
     }
   }
 

--- a/src/bots/zoom/src/bot.ts
+++ b/src/bots/zoom/src/bot.ts
@@ -36,18 +36,21 @@ export class ZoomBot extends Bot {
 
 
   async screenshot(fName: string = "screenshot.png") {
-    if (!this.browser) throw new Error("Browser not initialized");
-    if (!this.page) throw new Error("Page not initialized");
+    try {
+      if (!this.page) throw new Error("Page not initialized");
+      if (!this.browser) throw new Error("Browser not initialized");
 
-    const screenshot = await this.page.screenshot({
-      type: "png",
-      encoding: "binary",
-    });
+      const screenshot = await this.page.screenshot({
+        type: "png",
+      });
 
-    // Save the screenshot to a file
-    const screenshotPath = path.resolve(`/tmp/${fName}`);
-    fs.writeFileSync(screenshotPath, screenshot);
-    console.log(`Screenshot saved to ${screenshotPath}`);
+      // Save the screenshot to a file
+      const screenshotPath = path.resolve(`/tmp/${fName}`);
+      fs.writeFileSync(screenshotPath, screenshot);
+      console.log(`Screenshot saved to ${screenshotPath}`);
+    } catch (e) {
+      console.log('Error taking screenshot:', e);
+    }
   }
 
   async checkKicked(): Promise<boolean> {
@@ -104,7 +107,7 @@ export class ZoomBot extends Bot {
     // Create a URL object from the url
     const page = this.page;
     const urlObj = new URL(this.url);
-    
+
     // Navigates to the url
     console.log("Atempting to open link");
     await page.goto(urlObj.href);
@@ -167,7 +170,7 @@ export class ZoomBot extends Bot {
 
     // Create the Stream
     this.stream = await getStream(this.page as any, { audio: true, video: true });
-  
+
     // Create and Write the recording to a file, pipe the stream to a fileWriteStream
     this.file = fs.createWriteStream(this.recordingPath);
     this.stream.pipe(this.file);
@@ -179,9 +182,9 @@ export class ZoomBot extends Bot {
    */
   async stopRecording() {
 
-      // End the recording and close the file
-      if (this.stream)
-        this.stream.destroy();
+    // End the recording and close the file
+    if (this.stream)
+      this.stream.destroy();
 
   }
 


### PR DESCRIPTION
### TL;DR

Improved screenshot functionality across Meet, Teams, and Zoom bots with consistent error handling.

I suspect that this fixes the long typecheck Check times.

### What changed?

- Standardized the screenshot method implementation across all three bots (Meet, Teams, Zoom)
- Added proper error handling with try/catch blocks in all screenshot methods
- Added browser initialization check before taking screenshots
- Moved null checks inside try blocks for better error handling flow
- Removed unnecessary `encoding: "binary"` parameter from Teams and Zoom bots
- Formatted code for consistency across all bots

### How to test?

1. Initialize each bot (Meet, Teams, Zoom)
2. Call the screenshot method on each bot
3. Verify screenshots are saved to `/tmp/{filename}`
4. Test error scenarios by calling screenshot before page/browser initialization

### Why make this change?

This change improves error handling and creates consistency across all bots' screenshot functionality. By standardizing the implementation, we ensure that all bots handle screenshot operations in the same way, making the codebase more maintainable and reducing the chance of bugs occurring in only one bot implementation.