### PR TITLE
docs: change from AGPL to LGPL in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ To get started with MeetingBot, you'll need to set up the infrastructure and con
 
 ## License
 
-This project is licensed under the GNU Affero General Public License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the GNU Lesser General Public License - see the [LICENSE](LICENSE) file for details.
 
 In general, this means you can use this code in any way you want, commercially or not, as long as you share any modifications you make to the source code.
 


### PR DESCRIPTION
### TL;DR

Updated project license from AGPL to LGPL.

### What changed?

Changed the license declaration in the README.md from GNU Affero General Public License (AGPL) to GNU Lesser General Public License (LGPL).

### How to test?

Verify that the README.md correctly states the project is now licensed under the GNU Lesser General Public License.

### Why make this change?

The LGPL is less restrictive than AGPL, allowing for easier integration with other software projects. This change maintains the requirement to share modifications to the source code while providing more flexibility for users of the library.