### PR TITLE
fix: correct bots directory path in deployment service

### DIFF
--- a/src/server/src/server/api/services/botDeployment.ts
+++ b/src/server/src/server/api/services/botDeployment.ts
@@ -78,7 +78,7 @@ export async function deployBot({
 
   try {
     // Get the absolute path to the bots directory (parent directory)
-    const botsDir = path.resolve(__dirname, "../../../bots");
+    const botsDir = path.resolve(__dirname, "../../../../../bots");
 
     // Merge default config with user provided config
 


### PR DESCRIPTION
### TL;DR

Fixed the path to the bots directory in the bot deployment service.

### What changed?

Updated the path resolution for the bots directory in `botDeployment.ts` from `"../../../bots"` to `"../../../../../bots"` to correctly locate the bots directory from the current file location.

### How to test?

1. Deploy a bot using the deployment service
2. Verify that the bot is correctly deployed to the proper directory
3. Confirm that no path-related errors occur during deployment

### Why make this change?

The previous path was incorrect, causing the system to look for the bots directory in the wrong location. This fix ensures that the deployment service can properly locate and interact with the bots directory, preventing deployment failures due to path resolution issues.