### PR TITLE
refactor: replace SSE with manual recording fetch for serverless compatibility

### DIFF
--- a/src/example-app/README.md
+++ b/src/example-app/README.md
@@ -7,6 +7,8 @@ It allows you to enter a meeting link. A meeting bot will be summoned to the mee
 
 After the meeting, the recording will be available in the interface, and there is a button to transcribe & summarize the meeting using AI. (Uses OpenAI Whisper and GPT-4o.)
 
+Note: The MeetingBot server automatically sends the recording to this application's NextJS backend when the meeting is finished. However, we still need a button in this example app frontend to fetch the recording from this example app's NextJS backend. (We had it automatically populate before using SSE, but we had to remove SSE in order for this example app to run in a serverless environment.)
+
 ## Running
 
 Ensure the backend and frontend are both running before you start the example app.

--- a/src/example-app/src/app/api/callback/route.ts
+++ b/src/example-app/src/app/api/callback/route.ts
@@ -3,51 +3,17 @@
 import { NextResponse } from 'next/server';
 
 let recordingLink = '';
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let clients: any[] = []; // Store connected clients
 
 // Get Key
 const BOT_API_KEY = process.env.BOT_API_KEY;
 const MEETINGBOT_END_POINT = process.env.MEETINGBOT_END_POINT;
 
-export async function GET(req: Request) {
-  const { searchParams } = new URL(req.url);
-  const isSSE = searchParams.get('sse') === 'true';
-
-  // Construct the webhook
-  if (isSSE) {
-    const stream = new ReadableStream({
-      start(controller) {
-        const client = {
-          send: (data: string) => controller.enqueue(`data: ${data}\n\n`),
-          close: () => controller.close(),
-        };
-        clients.push(client);
-
-        // Remove client on disconnect
-        req.signal.addEventListener('abort', () => {
-          clients = clients.filter((c) => c !== client);
-        });
-      },
-    });
-
-    //Pass the Response back
-    return new Response(stream, {
-      headers: {
-        'Content-Type': 'text/event-stream',
-        'Cache-Control': 'no-cache',
-        'Connection': 'keep-alive',
-      },
-    });
-  }
-
-  // Fallback for non-SSE requests
+export async function GET() {
   return NextResponse.json({ link: recordingLink }, { status: 200 });
 }
 
 // Validate Bot is finished and exists
 const validateBot = async (botId: number) => {
-
   // Validate
   if (!BOT_API_KEY) return NextResponse.json({ error: 'Missing required environment variable: BOT_API_KEY' }, { status: 500 });
   if (!MEETINGBOT_END_POINT) return NextResponse.json({ error: 'Missing required environment variable: MEETINGBOT_END_POINT' }, { status: 500 });
@@ -72,10 +38,8 @@ const validateBot = async (botId: number) => {
   return true;
 }
 
-
 export async function POST(req: Request) {
   try {
-
     // Validate
     if (!BOT_API_KEY) return NextResponse.json({ error: 'Missing required environment variable: BOT_API_KEY' }, { status: 500 });
     if (!MEETINGBOT_END_POINT) return NextResponse.json({ error: 'Missing required environment variable: MEETINGBOT_END_POINT' }, { status: 500 });
@@ -85,16 +49,11 @@ export async function POST(req: Request) {
     if (botId === null)
       return NextResponse.json('Malfored Body - botId is not defined', { status: 400 });
 
-    // Ideally - your app would be hosted on AWS along with the bot service, or 
-    // you would have a secure way of communicating with the bot service.
-    // As this is an example app, we will just allow any request to come through.
-
     // We will just validate that the bot is finished.
     const validationResult = validateBot(botId);
     if (!validationResult)
       return NextResponse.json('Bot Validation Failed', { status: 403 });
 
-    //
     // Send request to MeetingBot API to get the signed Recording URL from S3
     const recordingResponse = await fetch(`${MEETINGBOT_END_POINT}/api/bots/${botId}/recording`, {
       method: 'GET',
@@ -110,9 +69,6 @@ export async function POST(req: Request) {
     //Save
     recordingLink = recordingUrl;
     console.log('Set Recording link to:', recordingLink);
-
-    // Notify all connected clients
-    clients.forEach((client) => client.send(JSON.stringify({ recordingLink })));
 
     // Passback
     return NextResponse.json({ message: 'OK' }, { status: 200 });

--- a/src/example-app/src/app/components/MeetingBotCreator.tsx
+++ b/src/example-app/src/app/components/MeetingBotCreator.tsx
@@ -199,7 +199,7 @@ export default function MeetingBotCreator() {
   const inputFieldClass = 'my-[20px] p-2 w-full rounded-md border border-input bg-background shadow-sm hover:bg-accent mt-0' +
     (detectedBot ? ' font-medium text-accent-foreground hover:text-accent-foreground' : ' text-muted-foreground hover:text-muted-foreground');
 
-  const shortResponse = /"id": \d+/.test(response) ? 'Bot was created.' : 'Bot was not created.';
+  const shortResponse = response.id ? 'Bot was created.' : 'Bot was not created.';
 
   return (
     <div style={{ width: '50%', minWidth: '300px', padding: '20px' }}>


### PR DESCRIPTION
### TL;DR

Replaced SSE implementation with a manual recording fetch button to support serverless environments.

### What changed?

- Removed Server-Sent Events (SSE) implementation from the callback API route
- Added a "Check for Recording" button in the RecordingPlayer component to manually fetch recordings
- Updated the README to explain why we switched from automatic population to a manual button
- Fixed response parsing in MeetingBotCreator component
- Removed client tracking and notification code that was used for SSE

### How to test?

1. Run the example app
2. Create a meeting bot by entering a meeting link
3. After the meeting ends, click the "Check for Recording" button
4. Verify the recording appears and can be played
5. Test the transcribe and summarize functionality

### Why make this change?

The previous implementation used Server-Sent Events (SSE) to automatically update the UI when recordings became available. However, SSE connections are not well-supported in serverless environments due to their long-lived nature. This change makes the application compatible with serverless deployments by replacing the automatic updates with a manual fetch button, ensuring the example app can run in a wider range of hosting environments.