### PR TITLE
meet bot: support for open rooms and handling info popup

### DIFF
--- a/src/bots/meet/src/bot.ts
+++ b/src/bots/meet/src/bot.ts
@@ -23,6 +23,7 @@ const userAgent =
 // Constant Selectors
 const enterNameField = 'input[type="text"][aria-label="Your name"]';
 const askToJoinButton = '//button[.//span[text()="Ask to join"]]';
+const joinNowButton = '//button[.//span[text()="Join now"]]';
 const gotKickedDetector = '//button[.//span[text()="Return to home screen"]]';
 const leaveButton = `//button[@aria-label="Leave call"]`;
 const peopleButton = `//button[@aria-label="People"]`;
@@ -297,10 +298,13 @@ export class MeetsBot extends Bot {
       console.log('Could not turn off Camera -- probably already off.');
     }
 
-    // Click the "Ask to join" button
-    console.log('Waiting for the "Ask to join" button...');
-    await this.page.waitForSelector(askToJoinButton, { timeout: 60000 });
-    await this.page.click(askToJoinButton);
+    console.log('Waiting for either the "Join now" or "Ask to join" button to appear...');
+    const entryButton = await Promise.race([
+      this.page.waitForSelector(joinNowButton, { timeout: 60000 }).then(() => joinNowButton),
+      this.page.waitForSelector(askToJoinButton, { timeout: 60000 }).then(() => askToJoinButton),
+    ]);
+
+    await this.page.click(entryButton);
 
     //Should Exit after 1 Minute
     console.log("Awaiting Entry ....");
@@ -665,7 +669,7 @@ export class MeetsBot extends Bot {
     // Loop -- check for end meeting conditions every second
     console.log("Waiting until a leave condition is fulfilled..");
     while (true) {
-      
+
       // Check if it's only me in the meeting
       console.log('Checking if 1 Person Remaining ...', this.participantCount);
       if (this.participantCount === 1) {

--- a/src/bots/meet/src/bot.ts
+++ b/src/bots/meet/src/bot.ts
@@ -520,6 +520,19 @@ export class MeetsBot extends Bot {
     return false;
   }
 
+  /**
+   * Check if a pop-up appeared. If so, close it.
+   */
+  async handleInfoPopup() {
+    try {
+      console.log("Waiting for the 'Others might see you differently' popup...");
+      await this.page.waitForSelector(infoPopupClick, { timeout: 1000 });
+      console.log("Clicking the popup...");
+      await this.page.click(infoPopupClick, { timeout: 500 });
+    } catch (e) {
+      console.log("No Popup Found, continuing.");
+    }
+  }
 
   /**
    * 
@@ -540,15 +553,7 @@ export class MeetsBot extends Bot {
     console.log("Starting Recording");
     this.startRecording();
 
-    // Check if a popup appeared
-    try {
-      console.log("Waiting for the 'Others might see you differently' popup...");
-      await this.page.waitForSelector(infoPopupClick, { timeout: 5000 });
-      console.log("Clicking the popup...");
-      await this.page.click(infoPopupClick, { timeout: 500 });
-    } catch (e) {
-      console.log("No Popup Found, continuing.");
-    }
+    await this.handleInfoPopup();
 
     // Meeting Join Actions
     try {
@@ -660,7 +665,7 @@ export class MeetsBot extends Bot {
     // Loop -- check for end meeting conditions every second
     console.log("Waiting until a leave condition is fulfilled..");
     while (true) {
-
+      
       // Check if it's only me in the meeting
       console.log('Checking if 1 Person Remaining ...', this.participantCount);
       if (this.participantCount === 1) {
@@ -684,6 +689,8 @@ export class MeetsBot extends Bot {
         break; //exit loop
 
       }
+
+      await this.handleInfoPopup();
 
       // Reset Loop
       console.log('Waiting 5 seconds.')

--- a/src/bots/meet/src/bot.ts
+++ b/src/bots/meet/src/bot.ts
@@ -529,13 +529,12 @@ export class MeetsBot extends Bot {
    */
   async handleInfoPopup() {
     try {
-      console.log("Waiting for the 'Others might see you differently' popup...");
       await this.page.waitForSelector(infoPopupClick, { timeout: 1000 });
-      console.log("Clicking the popup...");
-      await this.page.click(infoPopupClick, { timeout: 500 });
     } catch (e) {
-      console.log("No Popup Found, continuing.");
+      return;
     }
+    console.log("Clicking the popup...");
+    await this.page.click(infoPopupClick);
   }
 
   /**
@@ -557,6 +556,7 @@ export class MeetsBot extends Bot {
     console.log("Starting Recording");
     this.startRecording();
 
+    console.log("Waiting for the 'Others might see you differently' popup...");
     await this.handleInfoPopup();
 
     // Meeting Join Actions

--- a/src/bots/meet/src/bot.ts
+++ b/src/bots/meet/src/bot.ts
@@ -135,7 +135,7 @@ export class MeetsBot extends Bot {
     onEvent: (eventType: EventCode, data?: any) => Promise<void>
   ) {
     super(botSettings, onEvent);
-    this.recordingPath = path.resolve('/tmp/recording.mp4');
+    this.recordingPath = path.resolve('/rec/recording.mp4');
 
     this.browserArgs = [
       "--incognito",

--- a/src/bots/meet/src/bot.ts
+++ b/src/bots/meet/src/bot.ts
@@ -527,9 +527,9 @@ export class MeetsBot extends Bot {
   /**
    * Check if a pop-up appeared. If so, close it.
    */
-  async handleInfoPopup() {
+  async handleInfoPopup(timeout = 5000) {
     try {
-      await this.page.waitForSelector(infoPopupClick, { timeout: 1000 });
+      await this.page.waitForSelector(infoPopupClick, { timeout });
     } catch (e) {
       return;
     }
@@ -694,7 +694,7 @@ export class MeetsBot extends Bot {
 
       }
 
-      await this.handleInfoPopup();
+      await this.handleInfoPopup(1000);
 
       // Reset Loop
       console.log('Waiting 5 seconds.')


### PR DESCRIPTION
## Changes

1. When a meeting is publicly available (has "open" option) the button is different, so now bot checks for that as well
2. The "Others might see you differently popup" also can appear during the meeting after another attendee joins, so now the bots regularly checks for it
3. Changed the directory for recordings from /tmp to /rec, just for the comfort of mounting the volume locally. Hopefully has no impact on anything else? 