### PR TITLE
feat(meet): add activity detection, inactivity timeout and speaker timeframes

### DIFF
--- a/src/bots/envBotDataExample.ts
+++ b/src/bots/envBotDataExample.ts
@@ -29,6 +29,7 @@ const botData: BotConfig = {
     waitingRoomTimeout: 3600000,
     noOneJoinedTimeout: 3600000,
     everyoneLeftTimeout: 3600000,
+    inactivityTimeout: 3600000,
   },
   callbackUrl: "<CALLBACK_URL>",
 };

--- a/src/bots/meet/src/bot.ts
+++ b/src/bots/meet/src/bot.ts
@@ -4,7 +4,7 @@ import { saveVideo, PageVideoCapture } from "playwright-video";
 import { CaptureOptions } from "playwright-video/build/PageVideoCapture";
 import StealthPlugin from "puppeteer-extra-plugin-stealth";
 import { setTimeout } from "timers/promises";
-import { BotConfig, EventCode, WaitingRoomTimeoutError } from "../../src/types";
+import { BotConfig, EventCode, SpeakerTimeframe, WaitingRoomTimeoutError } from "../../src/types";
 import { Bot } from "../../src/bot";
 import * as fs from 'fs';
 import path from "path";
@@ -37,6 +37,11 @@ const infoPopupClick = `//button[.//span[text()="Got it"]]`;
 const SCREEN_WIDTH = 1920;
 const SCREEN_HEIGHT = 1080;
 
+type Participant = {
+  id: string;
+  name: string;
+};
+
 /**
  * @param amount Milliseconds
  * @returns Random Number within 10% of the amount given, mean at amount
@@ -53,8 +58,12 @@ declare global {
     saveChunk: (chunk: number[]) => void;
     stopRecording: () => void;
 
-    setParticipantCount: (count: number) => void;
-    addParticipantCount: (count: number) => void;
+    addParticipant: (participant: Participant) => void;
+    updateParticipants: (participants: Participant[]) => void;
+    onParticipantJoin: (participant: Participant) => void;
+    onParticipantLeave: (participant: Participant) => void;
+    registerParticipantSpeaking: (participant: Participant) => void;
+    observeSpeech: (node: any, participant: Participant) => void;
 
     recorder: MediaRecorder | undefined;
   }
@@ -118,11 +127,16 @@ export class MeetsBot extends Bot {
   kicked: boolean = false;
   recordingPath: string;
 
-  private recordBuffer: Buffer[] = [];
+  private participants: Participant[] = [];
+  private speakerTimeframes: {
+    [participantName: string]: [number];
+  } = {};
   private startedRecording: boolean = false;
 
   private timeAloneStarted: number = Infinity;
-  participantCount: number = 0;
+  private lastActivity: number | undefined = undefined;
+  private recordingStartedAt: number = 0;
+  private maxDuration: number = 1000 * 60 * 180;
 
   private ffmpegProcess: ChildProcessWithoutNullStreams | null;
 
@@ -181,6 +195,43 @@ export class MeetsBot extends Bot {
 
     // Give Back the path
     return this.recordingPath;
+  }
+
+  /**
+   * Gets the speaker timeframes.
+   * @returns {Array} - Returns an array of objects containing speaker names and their respective start and end times.
+   */
+  getSpeakerTimeframes(): SpeakerTimeframe[] {
+    const processedTimeframes: {
+      speakerName: string;
+      start: number;
+      end: number;
+    }[] = [];
+
+    const threshold = 3000;
+    for (const [speakerName, timeframesArray] of Object.entries(
+      this.speakerTimeframes
+    )) {
+      let start = timeframesArray[0];
+      let end = timeframesArray[0];
+
+      for (let i = 1; i < timeframesArray.length; i++) {
+        const currentTimeframe = timeframesArray[i]!;
+        if (currentTimeframe - end < threshold) {
+          end = currentTimeframe;
+        } else {
+          if (end - start > 500) {
+            processedTimeframes.push({ speakerName, start, end });
+          }
+          start = currentTimeframe;
+          end = currentTimeframe;
+        }
+      }
+      processedTimeframes.push({ speakerName, start, end });
+    }
+    processedTimeframes.sort((a, b) => a.start - b.start || a.end - b.end);
+
+    return processedTimeframes;
   }
 
   /**
@@ -575,54 +626,108 @@ export class MeetsBot extends Bot {
     }
 
     // Set up participant monitoring
+    await this.page.exposeFunction(
+      "addParticipant",
+      async (participant: Participant) => {
+        this.participants.push(participant);
+      }
+    );
 
-    // Monitor for participants joining
+    await this.page.exposeFunction(
+      "updateParticipants",
+      async (participants: Participant[]) => {
+        participants.forEach(async (p) => {
+          if (!this.participants.find((x) => x.id === p.id)) {
+            this.participants.push(p);
+            await this.onEvent(EventCode.PARTICIPANT_JOIN, p);
+          } else if (this.participants.find((x) => x.id === p.id)) {
+            await this.onEvent(EventCode.PARTICIPANT_LEAVE, p);
+            this.participants = this.participants.filter((p) => p.id !== p.id);
+            this.timeAloneStarted =
+              this.participants.length === 1 ? Date.now() : Infinity;
+          }
+        });
+      }
+    );
+
     await this.page.exposeFunction(
       "onParticipantJoin",
-      async (participantId: string) => {
-        await this.onEvent(EventCode.PARTICIPANT_JOIN, { participantId });
+      async (participant: Participant) => {
+        this.participants.push(participant);
+        await this.onEvent(EventCode.PARTICIPANT_JOIN, participant);
       }
     );
 
-    // Monitor for participants leaving
     await this.page.exposeFunction(
       "onParticipantLeave",
-      async (participantId: string) => {
-        await this.onEvent(EventCode.PARTICIPANT_LEAVE, { participantId });
+      async (participant: Participant) => {
+        await this.onEvent(EventCode.PARTICIPANT_LEAVE, participant);
+        this.participants = this.participants.filter(
+          (p) => p.id !== participant.id
+        );
+        this.timeAloneStarted =
+          this.participants.length === 1 ? Date.now() : Infinity;
       }
     );
 
+    await this.page.exposeFunction(
+      "registerParticipantSpeaking",
+      (participant: Participant) => {
+        this.lastActivity = Date.now();
+        const relativeTimestamp = Date.now() - this.recordingStartedAt;
+        console.log(
+          `Participant ${participant.name} is speaking at ${relativeTimestamp}ms`
+        );
 
-    // Expose function to update participant count
-    await this.page.exposeFunction("addParticipantCount", (count: number) => {
-      this.participantCount += count;
-      console.log("Updated Participant Count:", this.participantCount);
-
-      if (this.participantCount == 1) {
-        this.timeAloneStarted = Date.now();
-      } else {
-        this.timeAloneStarted = Infinity;
+        if (!this.speakerTimeframes[participant.name]) {
+          this.speakerTimeframes[participant.name] = [relativeTimestamp];
+        } else {
+          this.speakerTimeframes[participant.name]!.push(relativeTimestamp);
+        }
       }
-    });
+    );
 
     // Add mutation observer for participant list
     // Use in the browser context to monitor for participants joining and leaving
     await this.page.evaluate(() => {
-
       const peopleList = document.querySelector('[aria-label="Participants"]');
       if (!peopleList) {
         console.error("Could not find participants list element");
         return;
       }
 
-      // Initialize participant count
-      const initialParticipants = peopleList.querySelectorAll('[data-participant-id]').length;
-      window.addParticipantCount(initialParticipants); // initially 0
-      console.log(`Initial participant count: ${initialParticipants}`);
+      const initialParticipants = peopleList.childNodes;
 
-      // Set up mutation observer
+      window.observeSpeech = (node, participant) => {
+        console.debug("Observing speech for participant:", participant.name);
+        const activityObserver = new MutationObserver((mutations) => {
+          mutations.forEach(() => {
+            console.debug(
+              "Participant speaking inside callback:",
+              participant.name
+            );
+            window.registerParticipantSpeaking(participant);
+          });
+        });
+        activityObserver.observe(node, {
+          attributes: true,
+          subtree: true,
+          childList: true,
+          attributeFilter: ["class"],
+        });
+      };
+
+      initialParticipants.forEach((node: any) => {
+        const participant = {
+          id: node.getAttribute("data-participant-id"),
+          name: node.getAttribute("aria-label"),
+        };
+        window.addParticipant(participant);
+        window.observeSpeech(node, participant);
+      });
+
       console.log("Setting up mutation observer on participants list");
-      const observer = new MutationObserver((mutations) => {
+      const peopleObserver = new MutationObserver((mutations) => {
         mutations.forEach((mutation) => {
           if (mutation.type === "childList") {
             mutation.addedNodes.forEach((node: any) => {
@@ -632,35 +737,48 @@ export class MeetsBot extends Bot {
               ) {
                 console.log(
                   "Participant joined:",
-                  node.getAttribute("data-participant-id")
+                  node.getAttribute("aria-label")
                 );
-                // @ts-ignore
-                window.onParticipantJoin(
-                  node.getAttribute("data-participant-id")
-                );
-                window.addParticipantCount(1);
+                const participant = {
+                  id: node.getAttribute("data-participant-id"),
+                  name: node.getAttribute("aria-label"),
+                };
+                window.onParticipantJoin(participant);
+                window.observeSpeech(node, participant);
               }
             });
             mutation.removedNodes.forEach((node: any) => {
               if (
+                node.nodeType === Node.ELEMENT_NODE &&
                 node.getAttribute &&
                 node.getAttribute("data-participant-id")
               ) {
                 console.log(
                   "Participant left:",
-                  node.getAttribute("data-participant-id")
+                  node.getAttribute("aria-label")
                 );
-                // @ts-ignore
-                window.onParticipantLeave(
-                  node.getAttribute("data-participant-id")
-                );
-                window.addParticipantCount(-1);
+                window.onParticipantLeave({
+                  id: node.getAttribute("data-participant-id"),
+                  name: node.getAttribute("aria-label"),
+                });
+              } else {
+                const newParticipantList: any = [];
+                document
+                  .querySelector('[aria-label="Participants"]')
+                  ?.childNodes.forEach((node: any) => {
+                    const participant = {
+                      id: node.getAttribute("data-participant-id"),
+                      name: node.getAttribute("aria-label"),
+                    };
+                    newParticipantList.push(participant);
+                  });
+                window.updateParticipants(newParticipantList);
               }
             });
           }
         });
       });
-      observer.observe(peopleList, { childList: true, subtree: true });
+      peopleObserver.observe(peopleList, { childList: true, subtree: true });
     });
 
     //
@@ -671,8 +789,7 @@ export class MeetsBot extends Bot {
     while (true) {
 
       // Check if it's only me in the meeting
-      console.log('Checking if 1 Person Remaining ...', this.participantCount);
-      if (this.participantCount === 1) {
+      if (this.participants.length === 1) {
 
         const leaveMs = this.settings?.automaticLeave?.everyoneLeftTimeout ?? 30000; // Default to 30 seconds if not set
         const msDiff = Date.now() - this.timeAloneStarted;
@@ -692,6 +809,16 @@ export class MeetsBot extends Bot {
         this.kicked = true; //store
         break; //exit loop
 
+      }
+
+      // Check if there has been no activity, case for when only bots stay in the meeting
+      if (
+        this.participants.length > 1 &&
+        this.lastActivity &&
+        Date.now() - this.lastActivity > this.settings.automaticLeave.inactivityTimeout
+      ) {
+        console.log("No Activity for 5 minutes");
+        break;
       }
 
       await this.handleInfoPopup(1000);

--- a/src/bots/meet/src/bot.ts
+++ b/src/bots/meet/src/bot.ts
@@ -1,7 +1,6 @@
 import { chromium } from "playwright-extra";
 import { Browser, Page } from "playwright";
-import { saveVideo, PageVideoCapture } from "playwright-video";
-import { CaptureOptions } from "playwright-video/build/PageVideoCapture";
+import {  PageVideoCapture } from "playwright-video";
 import StealthPlugin from "puppeteer-extra-plugin-stealth";
 import { setTimeout } from "timers/promises";
 import { BotConfig, EventCode, SpeakerTimeframe, WaitingRoomTimeoutError } from "../../src/types";
@@ -100,6 +99,9 @@ declare global {
  * @method getRecordingPath - Retrieves the file path of the recording.
  * @returns {string} The path to the recording file.
  * 
+ * @method getSpeakerTimeframes - Retrieves the timeframes of speakers in the meeting.
+ * @returns {Array} An array of objects containing speaker names and their respective start and end times.
+ * 
  * @method getContentType - Retrieves the content type of the recording file.
  * @returns {string} The content type of the recording file.
  * 
@@ -128,7 +130,7 @@ export class MeetsBot extends Bot {
   recordingPath: string;
 
   private participants: Participant[] = [];
-  private speakerTimeframes: {
+  private registeredActivityTimestamps: {
     [participantName: string]: [number];
   } = {};
   private startedRecording: boolean = false;
@@ -136,7 +138,6 @@ export class MeetsBot extends Bot {
   private timeAloneStarted: number = Infinity;
   private lastActivity: number | undefined = undefined;
   private recordingStartedAt: number = 0;
-  private maxDuration: number = 1000 * 60 * 180;
 
   private ffmpegProcess: ChildProcessWithoutNullStreams | null;
 
@@ -208,16 +209,17 @@ export class MeetsBot extends Bot {
       end: number;
     }[] = [];
 
-    const threshold = 3000;
+    // If time between chunks is less than this, we consider it the same utterance.
+    const utteranceThresholdMs = 3000;
     for (const [speakerName, timeframesArray] of Object.entries(
-      this.speakerTimeframes
+      this.registeredActivityTimestamps
     )) {
       let start = timeframesArray[0];
       let end = timeframesArray[0];
 
       for (let i = 1; i < timeframesArray.length; i++) {
         const currentTimeframe = timeframesArray[i]!;
-        if (currentTimeframe - end < threshold) {
+        if (currentTimeframe - end < utteranceThresholdMs) {
           end = currentTimeframe;
         } else {
           if (end - start > 500) {
@@ -679,10 +681,10 @@ export class MeetsBot extends Bot {
           `Participant ${participant.name} is speaking at ${relativeTimestamp}ms`
         );
 
-        if (!this.speakerTimeframes[participant.name]) {
-          this.speakerTimeframes[participant.name] = [relativeTimestamp];
+        if (!this.registeredActivityTimestamps[participant.name]) {
+          this.registeredActivityTimestamps[participant.name] = [relativeTimestamp];
         } else {
-          this.speakerTimeframes[participant.name]!.push(relativeTimestamp);
+          this.registeredActivityTimestamps[participant.name]!.push(relativeTimestamp);
         }
       }
     );

--- a/src/bots/src/bot.ts
+++ b/src/bots/src/bot.ts
@@ -1,5 +1,5 @@
 import { reportEvent } from "./monitoring";
-import { type BotConfig, type EventCode } from "./types";
+import { type BotConfig, type EventCode, type SpeakerTimeframe } from "./types";
 
 export interface BotInterface {
   readonly settings: BotConfig;
@@ -77,6 +77,10 @@ export class Bot implements BotInterface {
    * @returns {string} contentType
    */
   getContentType(): string {
+    throw new Error("Method not implemented.");
+  }
+
+  getSpeakerTimeframes(): SpeakerTimeframe[] {
     throw new Error("Method not implemented.");
   }
 

--- a/src/bots/src/index.ts
+++ b/src/bots/src/index.ts
@@ -86,7 +86,9 @@ export const main = async () => {
   // Only report DONE if no error occurred
   if (!hasErrorOccurred) {
     // Report final DONE event
-    await reportEvent(botId, EventCode.DONE, { recording: key });
+    const speakerTimeframes = bot.getSpeakerTimeframes();
+    console.debug("Speaker timeframes:", speakerTimeframes);
+    await reportEvent(botId, EventCode.DONE, { recording: key, speakerTimeframes });
   }
 
   // Exit with appropriate code

--- a/src/bots/src/monitoring.ts
+++ b/src/bots/src/monitoring.ts
@@ -56,6 +56,7 @@ export const reportEvent = async (
           id: botId,
           status: eventType as unknown as Status,
           recording: eventData.recording,
+          speakerTimeframes: eventData.speakerTimeframes,
         });
       } else {
         await trpc.bots.updateBotStatus.mutate({

--- a/src/bots/src/trpc.ts
+++ b/src/bots/src/trpc.ts
@@ -1,5 +1,5 @@
 import { createTRPCProxyClient, httpBatchLink } from "@trpc/client";
-import { type AppRouter } from "../../backend/src/routers";
+import { type AppRouter } from "../../server/src/server/api/root";
 import superjson from "superjson";
 
 export const trpc = createTRPCProxyClient<AppRouter>({

--- a/src/bots/src/types.ts
+++ b/src/bots/src/types.ts
@@ -13,6 +13,7 @@ export type AutomaticLeave = {
   waitingRoomTimeout: number;
   noOneJoinedTimeout: number;
   everyoneLeftTimeout: number;
+  inactivityTimeout: number;
 };
 
 export type BotConfig = {
@@ -67,3 +68,9 @@ export class MeetingJoinError extends Error {
     this.name = "MeetingJoinError";
   }
 }
+
+export type SpeakerTimeframe = {
+  start: number;
+  end: number;
+  speakerName: string;
+};

--- a/src/bots/teams/src/bot.ts
+++ b/src/bots/teams/src/bot.ts
@@ -1,8 +1,7 @@
 import fs from "fs";
 import puppeteer, { Browser, Page } from "puppeteer";
 import { launch, getStream, wss } from "puppeteer-stream";
-import crypto from "crypto";
-import { BotConfig, EventCode, WaitingRoomTimeoutError } from "../../src/types";
+import { BotConfig, EventCode, SpeakerTimeframe, WaitingRoomTimeoutError } from "../../src/types";
 import { Bot } from "../../src/bot";
 import path from "path";
 import { Transform } from "stream";
@@ -35,6 +34,11 @@ export class TeamsBot extends Bot {
 
   getRecordingPath(): string {
     return this.recordingPath;
+  }
+
+  getSpeakerTimeframes(): SpeakerTimeframe[] {
+    // TODO: Implement this
+    return []
   }
 
   getContentType(): string {

--- a/src/bots/zoom/src/bot.ts
+++ b/src/bots/zoom/src/bot.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
-import puppeteer, { Page, Frame } from "puppeteer";
+import puppeteer, { Page } from "puppeteer";
 import { launch, getStream, wss } from "puppeteer-stream";
-import { BotConfig, EventCode, WaitingRoomTimeoutError } from "../../src/types";
+import { BotConfig, EventCode, WaitingRoomTimeoutError, SpeakerTimeframe } from "../../src/types";
 import { Bot } from "../../src/bot";
 import path from "path";
 
@@ -250,6 +250,11 @@ export class ZoomBot extends Bot {
   // Get the path to the recording file
   getRecordingPath(): string {
     return this.recordingPath;
+  }
+
+  getSpeakerTimeframes(): SpeakerTimeframe[] {
+    // TODO: Implement this
+    return []
   }
 
   // Get the content type of the recording file

--- a/src/server/src/server/api/routers/bots.ts
+++ b/src/server/src/server/api/routers/bots.ts
@@ -85,6 +85,7 @@ export const botsRouter = createTRPCRouter({
             waitingRoomTimeout: 300000, // 5 minutes
             noOneJoinedTimeout: 300000, // 5 minutes
             everyoneLeftTimeout: 300000, // 5 minutes
+            inactivityTimeout: 300000, // 5 minutes
           },
           callbackUrl: input.callbackUrl, // Credit to @martinezpl for this line -- cannot merge at time of writing due to capstone requirements
         };
@@ -160,6 +161,7 @@ export const botsRouter = createTRPCRouter({
           id: z.number(),
           status: status,
           recording: z.string().optional(),
+          speakerTimeframes: z.array(z.record(z.string(), z.any())).optional()
         })
         .refine(
           (data) => {
@@ -203,18 +205,22 @@ export const botsRouter = createTRPCRouter({
         // add the recording to the bot
         await ctx.db
           .update(bots)
-          .set({ recording: input.recording })
+          .set({ recording: input.recording, speakerTimeframes: input.speakerTimeframes })
           .where(eq(bots.id, bot.id));
 
         if (bot.callbackUrl) {
           // call the callback url
-          await fetch(bot.callbackUrl, {
-            method: "POST",
-            body: JSON.stringify({
-              botId: bot.id,
-              status: input.status,
-            }),
-          });
+          try {
+            await fetch(bot.callbackUrl, {
+              method: 'POST',
+              body: JSON.stringify({
+                botId: bot.id,
+                status: input.status,
+              }),
+            })
+          } catch (error) {
+            console.error('Error calling callback URL:', error)
+          }
         }
       }
       return result[0];

--- a/src/server/src/server/db/schema.ts
+++ b/src/server/src/server/db/schema.ts
@@ -164,6 +164,7 @@ const automaticLeaveSchema = z.object({
   waitingRoomTimeout: z.number(), // the milliseconds before the bot leaves the meeting if it is in the waiting room
   noOneJoinedTimeout: z.number(), // the milliseconds before the bot leaves the meeting if no one has joined
   everyoneLeftTimeout: z.number(), // the milliseconds before the bot leaves the meeting if everyone has left
+  inactivityTimeout: z.number(), // the milliseconds before the bot leaves the meeting if there has been no activity
 });
 export type AutomaticLeave = z.infer<typeof automaticLeaveSchema>;
 export const meetingInfoSchema = z.object({
@@ -241,6 +242,9 @@ export const bots = pgTable("bots", {
   endTime: timestamp("end_time").notNull(),
   // recording stuff
   recording: varchar("recording", { length: 255 }),
+  speakerTimeframes: json('speaker_timeframes')
+    .$type<Record<string, any>[]>()
+    .default([]),
   lastHeartbeat: timestamp("last_heartbeat"),
   // status stuff
   status: varchar("status", { length: 255 })


### PR DESCRIPTION
This approach has been working for me, but there may be issues arising from the integration with the new codebase as I haven't tested it as such yet.

We're putting a class observer on each participant node in the "People" section. 
Whenever a participant's activity icon moves, we register the timestamp (relative to the beginning of the meeting). 

At the end `getSpeakerTimeframes` contains an algorithm that transforms these timestamps into `SpeakerTimeframe[]` type like so:

```
[
{"speakerName": "John Cena", "start": 1500, "end": 9000}, 
{"speakerName": "Barrack Obama", "start": 9500, "end": 13500}
]
```