### PR TITLE
feat: don't send events and heartbeat in dev

### DIFF
--- a/src/bots/.env.example
+++ b/src/bots/.env.example
@@ -4,5 +4,8 @@ AWS_SECRET_ACCESS_KEY=your_secret_access_key
 AWS_BUCKET_NAME=your_bucket_name
 AWS_REGION=your_region
 
+# Environment (for enabling development logs)
+NODE_ENV='development'
+
 # Bot data (example - this will be set by the backend)
 BOT_DATA={"botId":1,"meetingUrl":"https://meet.google.com/xxx-xxxx-xxx","botName":"Meeting Bot","recordingPath":"./recording.mp4","automaticLeave":{"waitingRoomTimeout":300000,"noOneJoinedTimeout":300000,"everyoneLeftTimeout":300000}}

--- a/src/bots/src/index.ts
+++ b/src/bots/src/index.ts
@@ -13,6 +13,7 @@ export const main = async () => {
     "BOT_DATA",
     "AWS_BUCKET_NAME",
     "AWS_REGION",
+    "NODE_ENV",
   ] as const;
 
   // Check all required environment variables are present
@@ -42,10 +43,13 @@ export const main = async () => {
   // Create AbortController for heartbeat
   const heartbeatController = new AbortController();
 
-  // Start heartbeat in the background
-  console.log("Starting heartbeat");
-  const heartbeatInterval = botData.heartbeatInterval ?? 5000; // Default to 5 seconds if not set
-  startHeartbeat(botId, heartbeatController.signal, heartbeatInterval); 
+  // Do not start heartbeat in development
+  if (process.env.NODE_ENV !== "development") {
+    // Start heartbeat in the background
+    console.log("Starting heartbeat");
+    const heartbeatInterval = botData.heartbeatInterval ?? 5000; // Default to 5 seconds if not set
+    startHeartbeat(botId, heartbeatController.signal, heartbeatInterval);
+  }
 
   // Report READY_TO_DEPLOY event
   await reportEvent(botId, EventCode.READY_TO_DEPLOY);

--- a/src/bots/src/monitoring.ts
+++ b/src/bots/src/monitoring.ts
@@ -32,6 +32,11 @@ export const reportEvent = async (
   eventType: EventCode,
   eventData: any = null
 ) => {
+  // do not report events in development
+  if (process.env.NODE_ENV === "development") {
+    return;
+  }
+
   try {
     // Report event
     await trpc.bots.reportEvent.mutate({


### PR DESCRIPTION
### TL;DR

Added development mode to disable heartbeat and event reporting when running bots locally.

### Why make this change?

This change makes local development easier by preventing unnecessary heartbeat and event failures.