### PR TITLE
fix: correct app router import

### DIFF
--- a/src/bots/.prettierrc
+++ b/src/bots/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "singleQuote": true
+}

--- a/src/bots/src/trpc.ts
+++ b/src/bots/src/trpc.ts
@@ -1,12 +1,12 @@
-import { createTRPCProxyClient, httpBatchLink } from "@trpc/client";
-import { type AppRouter } from "../../backend/src/routers";
-import superjson from "superjson";
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
+import { type AppRouter } from '../../server/src/server/api/root';
+import superjson from 'superjson';
 
 export const trpc = createTRPCProxyClient<AppRouter>({
   transformer: superjson,
   links: [
     httpBatchLink({
-      url: process.env.BACKEND_URL || "http://localhost:3001/api/trpc",
+      url: process.env.BACKEND_URL || 'http://localhost:3001/api/trpc',
     }),
   ],
 });


### PR DESCRIPTION
### TL;DR

Updated tRPC client import path to point to the new server location.

### What changed?

- Changed the import path for `AppRouter` from `../../backend/src/routers` to `../../server/src/server/api/root`
- Standardized string quotes from double to single quotes

### How to test?

1. Verify that the bots can successfully connect to the backend API
2. Ensure that all tRPC calls from bots to the server work as expected
3. Check that the environment variable `BACKEND_URL` is still respected when set

### Why make this change?

The server code structure has been reorganized, moving the API router definition from the backend directory to the server directory. This change updates the import path to maintain compatibility with the new structure, ensuring the bots can properly communicate with the backend.