### PR TITLE
fix: typechecker on github

### DIFF
--- a/src/server/src/server/api/trpc.ts
+++ b/src/server/src/server/api/trpc.ts
@@ -148,6 +148,7 @@ const getStatusCode = (e: unknown) => {
         SERVICE_UNAVAILABLE: 503,
         GATEWAY_TIMEOUT: 504,
         UNSUPPORTED_MEDIA_TYPE: 415,
+        PAYMENT_REQUIRED: 402,
       }[e.code] ?? 500)
     : 500;
 };


### PR DESCRIPTION
The typechecker on GitHub was failing due to a discrepancy in the version of trpc on the GitHub actions image and the one we are using. I added the missing type in the trpc code.