### PR TITLE
[FIX] Fixed issue with Modal Ended modal

### DIFF
--- a/src/bots/zoom/src/bot.ts
+++ b/src/bots/zoom/src/bot.ts
@@ -257,7 +257,7 @@ export class ZoomBot extends Bot {
         try {
           // Wait for the "Ok" button to appear which indicates the meeting is over
           const okButton = await frame?.waitForSelector(
-              "button.zm-btn.zm-btn-legacy.zm-btn--primary.zm-btn__outline--blue",
+              'div[aria-label="Meeting is end now"] button.zm-btn.zm-btn-legacy.zm-btn--primary.zm-btn__outline--blue',
               { timeout: 1000 },
           );
 


### PR DESCRIPTION
Issue: The selector determined any legacy blue button as "Meeting Ended by Host" modal confirm. For example, "Meeting Recording" notification modal.

FIX: the selector is updated to match only the button in "Meeting Ended" modal