### PR TITLE
chore: disable server unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,23 +65,23 @@ jobs:
           TEST_EMAIL: ${{ secrets.TEST_EMAIL }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
 
-      - name: Run e2e tests
-        run: |
-          cd src/server
-          pnpx playwright install-deps
-          pnpm exec playwright install
-          pnpm test:e2e
-        env:
-          AUTH_GITHUB_ID: ${{ secrets.AUTH_GITHUB_ID }}
-          AUTH_GITHUB_SECRET: ${{ secrets.AUTH_GITHUB_SECRET }}
-          AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
-          AUTH_TRUST_HOST: "http://localhost:3000"
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          GITHUB_TOKEN: ${{ secrets.FEED_GITHUB_TOKEN }}
-          TEST_AUTH_SECRET: ${{ secrets.TEST_AUTH_SECRET }}
-          TEST_EMAIL: ${{ secrets.TEST_EMAIL }}
-          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+      # - name: Run e2e tests
+      #   run: |
+      #     cd src/server
+      #     pnpx playwright install-deps
+      #     pnpm exec playwright install
+      #     pnpm test:e2e
+      #   env:
+      #     AUTH_GITHUB_ID: ${{ secrets.AUTH_GITHUB_ID }}
+      #     AUTH_GITHUB_SECRET: ${{ secrets.AUTH_GITHUB_SECRET }}
+      #     AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
+      #     AUTH_TRUST_HOST: "http://localhost:3000"
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+      #     AWS_REGION: ${{ secrets.AWS_REGION }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      #     GITHUB_TOKEN: ${{ secrets.FEED_GITHUB_TOKEN }}
+      #     TEST_AUTH_SECRET: ${{ secrets.TEST_AUTH_SECRET }}
+      #     TEST_EMAIL: ${{ secrets.TEST_EMAIL }}
+      #     TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,24 +28,24 @@ jobs:
           cd src/server
           pnpm install
 
-      - name: Run server tests
-        run: |
-          cd src/server
-          pnpm test
-        env:
-          AUTH_GITHUB_ID: ${{ secrets.AUTH_GITHUB_ID }}
-          AUTH_GITHUB_SECRET: ${{ secrets.AUTH_GITHUB_SECRET }}
-          AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          GITHUB_TOKEN: ${{ secrets.FEED_GITHUB_TOKEN }}
-          TEST_AUTH_SECRET: ${{ secrets.TEST_AUTH_SECRET }}
-          TEST_EMAIL: ${{ secrets.TEST_EMAIL }}
-          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-          TEST_DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
+      # - name: Run server tests
+      #   run: |
+      #     cd src/server
+      #     pnpm test
+      #   env:
+      #     AUTH_GITHUB_ID: ${{ secrets.AUTH_GITHUB_ID }}
+      #     AUTH_GITHUB_SECRET: ${{ secrets.AUTH_GITHUB_SECRET }}
+      #     AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+      #     AWS_REGION: ${{ secrets.AWS_REGION }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      #     GITHUB_TOKEN: ${{ secrets.FEED_GITHUB_TOKEN }}
+      #     TEST_AUTH_SECRET: ${{ secrets.TEST_AUTH_SECRET }}
+      #     TEST_EMAIL: ${{ secrets.TEST_EMAIL }}
+      #     TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+      #     TEST_DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
 
       - name: Build
         run: |


### PR DESCRIPTION
Looks like there are some issues with the hosted database the tests are trying to run against, likely because the testing database we were using was torn down. As a temporary stopgap to prevent misleading unit tests from running, this PR disables the faulty tests.