### PR TITLE
fix: reduce validation steps for db migration

### DIFF
--- a/src/terraform/ecs.tf
+++ b/src/terraform/ecs.tf
@@ -230,7 +230,8 @@ resource "aws_ecs_task_definition" "server" {
   provisioner "local-exec" {
     environment = {
       NODE_TLS_REJECT_UNAUTHORIZED = "0"
-      DATABASE_URL                 = "postgresql://${aws_db_instance.this.username}:${random_password.db_password.result}@${aws_db_instance.this.endpoint}/${aws_db_instance.this.db_name}?sslmode=require"
+      DATABASE_URL                 = "postgresql://${aws_db_instance.this.username}:${random_password.db_password.result}@${aws_db_instance.this.endpoint}/${aws_db_instance.this.db_name}?sslmode=no-verify"
+      SKIP_ENV_VALIDATION          = "true"
     }
 
     command = "cd ../server && pnpm i && pnpm db:migrate && echo 'Database migrations completed successfully'"


### PR DESCRIPTION
this prevents migrations from failing if a .env file doesn't exist, and allows self-signed certs as used by RDS