### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 permissions:
   contents: read
 name: Server Unit Tests
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Server Unit Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/meetingbot/meetingbot/security/code-scanning/7](https://github.com/meetingbot/meetingbot/security/code-scanning/7)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code, installs dependencies, and builds (with all test steps commented out), it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow, just after the `name` field and before the `on` field. This will apply the least privilege principle to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
