### PR TITLE
feat: add rustfs (S3-compatible storage) for local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: server
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  rustfs:
+    image: rustfs/rustfs:latest
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      RUSTFS_ROOT_USER: rustfsadmin
+      RUSTFS_ROOT_PASSWORD: rustfsadmin
+    volumes:
+      - rustfs_data:/data
+    command: server /data --console-address ":9001"
+
+  init-rustfs:
+    image: amazon/aws-cli:latest
+    depends_on:
+      - rustfs
+    environment:
+      AWS_ACCESS_KEY_ID: rustfsadmin
+      AWS_SECRET_ACCESS_KEY: rustfsadmin
+    entrypoint: >
+      /bin/sh -c "
+        sleep 3 &&
+        aws --endpoint-url http://rustfs:9000 s3 mb s3://meetingbot-dev || true
+      "
+
+volumes:
+  postgres_data:
+  rustfs_data:

--- a/src/bots/.env.example
+++ b/src/bots/.env.example
@@ -4,6 +4,10 @@ AWS_SECRET_ACCESS_KEY=your_secret_access_key
 AWS_BUCKET_NAME=your_bucket_name
 AWS_REGION=your_region
 
+# Local S3-compatible storage (RustFS). Leave unset for real AWS S3.
+# AWS_S3_ENDPOINT=http://localhost:9000
+# AWS_S3_FORCE_PATH_STYLE=true
+
 # Environment (for enabling development logs)
 NODE_ENV='development'
 

--- a/src/bots/src/index.ts
+++ b/src/bots/src/index.ts
@@ -32,7 +32,13 @@ export const main = async () => {
   let key: string = "";
 
   // Initialize S3 client
-  const s3Client = createS3Client(process.env.AWS_REGION!, process.env.AWS_ACCESS_KEY_ID, process.env.AWS_SECRET_ACCESS_KEY);
+  const s3Client = createS3Client(
+    process.env.AWS_REGION!,
+    process.env.AWS_ACCESS_KEY_ID,
+    process.env.AWS_SECRET_ACCESS_KEY,
+    process.env.AWS_S3_ENDPOINT,
+    process.env.AWS_S3_FORCE_PATH_STYLE === "true",
+  );
   if (!s3Client) {
     throw new Error("Failed to create S3 client");
   }

--- a/src/bots/src/s3.ts
+++ b/src/bots/src/s3.ts
@@ -1,38 +1,38 @@
-import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { PutObjectCommand, S3Client, type S3ClientConfig } from "@aws-sdk/client-s3";
 import { readFileSync, promises as fsPromises } from "fs";
 import { Bot } from "./bot";
 import { randomUUID } from "crypto";
 
 /**
  * Creates an S3 Connection to the bucket.
- * 
+ *
  * @returns S3Client
  */
-export function createS3Client(region: string | undefined, accessKeyId: string | undefined, secretKey: string | undefined): S3Client|null {
+export function createS3Client(
+    region: string | undefined,
+    accessKeyId: string | undefined,
+    secretKey: string | undefined,
+    endpoint?: string,
+    forcePathStyle?: boolean,
+): S3Client|null {
 
     try {
 
         if (!region)
             throw new Error("Region is required");
 
-        // Create an S3 client with credentials if they are provided
-        // Local Development requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
-        if (accessKeyId && secretKey) {
-            return new S3Client({
-                region,
-                credentials: {
-                    accessKeyId: accessKeyId,
-                    secretAccessKey: secretKey!,
-                },
-            });
+        const config: S3ClientConfig = { region };
 
-            // Production
-            // Credientials is not required on AWS, so we can use the default constructor.
-        } else {
-            return new S3Client({
-                region,
-            });
+        if (endpoint) {
+            config.endpoint = endpoint;
+            config.forcePathStyle = forcePathStyle ?? true;
         }
+
+        if (accessKeyId && secretKey) {
+            config.credentials = { accessKeyId, secretAccessKey: secretKey };
+        }
+
+        return new S3Client(config);
 
     } catch (error) {
         return null;

--- a/src/bots/tests/s3startup.test.ts
+++ b/src/bots/tests/s3startup.test.ts
@@ -50,6 +50,25 @@ describe('Bot S3 Startup Tests', () => {
         const result = createS3Client(undefined, undefined, undefined);
         expect(result).toBeNull();
     });
+
+    it("creates an S3 client with a custom endpoint when provided", () => {
+        const mockRegion = "us-east-1";
+        const mockAccessKeyId = "rustfsadmin";
+        const mockSecretKey = "rustfsadmin";
+        const mockEndpoint = "http://localhost:9000";
+
+        createS3Client(mockRegion, mockAccessKeyId, mockSecretKey, mockEndpoint, true);
+
+        expect(S3Client).toHaveBeenCalledWith({
+            region: mockRegion,
+            endpoint: mockEndpoint,
+            forcePathStyle: true,
+            credentials: {
+                accessKeyId: mockAccessKeyId,
+                secretAccessKey: mockSecretKey,
+            },
+        });
+    });
 });
 
 describe('S3Client Upload Tests', () => {

--- a/src/server/.env.example
+++ b/src/server/.env.example
@@ -31,3 +31,6 @@ AWS_ACCESS_KEY_ID=""
 AWS_SECRET_ACCESS_KEY=""
 AWS_BUCKET_NAME=""
 AWS_REGION="us-east-2"
+
+# Local S3-compatible storage (RustFS). Leave unset for real AWS S3.
+# AWS_S3_ENDPOINT=http://localhost:9000

--- a/src/server/src/env.js
+++ b/src/server/src/env.js
@@ -43,6 +43,7 @@ export const env = createEnv({
       process.env.NODE_ENV === "test"
         ? z.preprocess(() => "fake_aws_region", z.string())
         : z.string(),
+    AWS_S3_ENDPOINT: z.string().url().optional(),
     ECS_TASK_DEFINITION_MEET:
       process.env.NODE_ENV === "production"
         ? z.string()
@@ -99,6 +100,7 @@ export const env = createEnv({
     AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
     AWS_BUCKET_NAME: process.env.AWS_BUCKET_NAME,
     AWS_REGION: process.env.AWS_REGION,
+    AWS_S3_ENDPOINT: process.env.AWS_S3_ENDPOINT,
     ECS_TASK_DEFINITION_MEET: process.env.ECS_TASK_DEFINITION_MEET,
     ECS_TASK_DEFINITION_TEAMS: process.env.ECS_TASK_DEFINITION_TEAMS,
     ECS_TASK_DEFINITION_ZOOM: process.env.ECS_TASK_DEFINITION_ZOOM,

--- a/src/server/src/server/utils/s3.ts
+++ b/src/server/src/server/utils/s3.ts
@@ -17,6 +17,10 @@ class S3ClientSingleton {
     S3ClientSingleton.instance ??= new S3Client({
       region: env.AWS_REGION,
       credentials: this.credentials,
+      ...(env.AWS_S3_ENDPOINT && {
+        endpoint: env.AWS_S3_ENDPOINT,
+        forcePathStyle: true,
+      }),
     });
 
     return S3ClientSingleton.instance;


### PR DESCRIPTION
Introduce docker-compose.yml with postgres + rustfs + bucket init services so developers can work on S3 features without an AWS account. S3 clients in both bots and server now accept an optional endpoint/forcePathStyle config via AWS_S3_ENDPOINT, falling back to real AWS S3 when unset.